### PR TITLE
Support gzipped files

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Compat 0.17
 DataValues
 PooledArrays 0.0.2
 DataStructures
+CodecZlib

--- a/src/TextParse.jl
+++ b/src/TextParse.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module TextParse
 
-using DataValues
+using DataValues, CodecZlib
 using Base.Test
 
 include("lib/compat.jl")

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -66,11 +66,7 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 - `colparsers`: Parsers to use for specified columns. This can be a vector or a dictionary from column name / column index (Int) to a "parser". The simplest parser is a type such as Int, Float64. It can also be a `dateformat"..."`, see [CustomParser](@ref) if you want to plug in custom parsing behavior
 - `type_detect_rows`: number of rows to use to infer the initial `colparsers` defaults to 20.
 """
-function csvread(file::String, delim=','; kwargs...)
-    open(file, "r") do io
-        csvread(io, delim; filename=file, kwargs...)
-    end
-end
+csvread(file::String, delim=','; kwargs...) = _csvread_f(file, delim; kwargs...)[1:2]
 
 function csvread(file::IOStream, delim=','; kwargs...)
     mmap_data = Mmap.mmap(file)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using TextParse
 
 import TextParse: tryparsenext, unwrap, failedat, AbstractToken, LocalOpts
+import CodecZlib: GzipCompressorStream
 using Base.Test
 
 # dumb way to compare two AbstractTokens
@@ -506,4 +507,19 @@ import TextParse: eatwhitespaces
     @test tryparsenext(percentparser, "10%")  |> unwrap == (10.0, 4)
     @test tryparsenext(percentparser, "10.32 %") |> unwrap == (10.32, 8)
     @test tryparsenext(percentparser, "2k%") |> failedat ==  2
+end
+
+@testset "read gzipped files" begin
+    fn   = joinpath(@__DIR__, "data", "a.csv")
+    fngz = fn*".gz"
+    open(fn, "r") do ior
+        open(GzipCompressorStream, fngz, "w") do iow
+            write(iow, ior)
+        end
+    end
+    @test csvread(fn)   == csvread(fngz)
+    @test csvread([fn]) == csvread([fngz])
+    if isfile(fngz)
+        rm(fngz)
+    end
 end


### PR DESCRIPTION
If files end with `.gz` we'll try to use `CodecZlib` to read through a decompression stream.