### PR TITLE
add feature to skip commented lines

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -65,7 +65,7 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 - `spacedelim`: (Bool) parse space-delimited files. `delim` has no effect if true.
 - `quotechar`: character used to quote strings, defaults to `"`
 - `escapechar`: character used to escape quotechar in strings. (could be the same as quotechar)
-- `commentstring`: ignore lines that begin with commentstring
+- `commentchar`: ignore lines that begin with commentchar
 - `nrows`: number of rows in the file. Defaults to `0` in which case we try to estimate this.
 - `skiplines_begin`: skips specified number of lines at the beginning of the file
 - `header_exists`: boolean specifying whether CSV file contains a header
@@ -150,7 +150,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                  spacedelim=false,
                  quotechar='"',
                  escapechar='"',
-                 commentstring="#",
+                 commentchar='#',
                  stringtype=String,
                  noresize=false,
                  rowno::Int=1,
@@ -196,7 +196,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     end
 
     # Ignore commented lines before the header.
-    pos, lines = eatcommentlines(str, pos, lastindex(str), commentstring)
+    pos, lines = eatcommentlines(str, pos, lastindex(str), commentchar)
     lineno += lines
 
     if header_exists
@@ -229,7 +229,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     # seed guesses using those from previous file
     guess, pos1 = guesscolparsers(str, canonnames, opts,
                                   pos, type_detect_rows, 
-                                  colparsers, commentstring,
+                                  colparsers, commentchar,
                                   nastrings, prev_parsers)
     if isempty(canonnames)
         canonnames = Any[1:length(guess);]
@@ -313,7 +313,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     @label retry
     try
         finalrows = parsefill!(str, opts, rec, nrows, cols, colspool,
-                               pos, lineno, rowno, lastindex(str), commentstring)
+                               pos, lineno, rowno, lastindex(str), commentchar)
         if !noresize
             resizecols(colspool, finalrows)
         end
@@ -463,7 +463,7 @@ function readcolnames(str, opts, pos, colnames)
 end
 
 function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
-                       nrows::Int, colparsers, commentstring="#", nastrings=NA_STRINGS,
+                       nrows::Int, colparsers, commentchar='#', nastrings=NA_STRINGS,
                        prevs=nothing)
     # Field type guesses
     guess = []
@@ -474,7 +474,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
         pos, _ = eatnewlines(str, pos)
 
         # Move past commented lines before guessing.
-        pos, _ = eatcommentlines(str, pos, lastindex(str), commentstring)
+        pos, _ = eatcommentlines(str, pos, lastindex(str), commentchar)
         pos > lastindex(str) && break
 
         lineend = getlineend(str, pos)
@@ -525,7 +525,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
 end
 
 function parsefill!(str::AbstractString, opts, rec::RecN{N}, nrecs, cols, colspool,
-                    pos, lineno, rowno, l=lastindex(str), commentstring="#") where {N}
+                    pos, lineno, rowno, l=lastindex(str), commentchar='#') where {N}
     pos, lines = eatnewlines(str, pos)
     lineno += lines
 
@@ -534,7 +534,7 @@ function parsefill!(str::AbstractString, opts, rec::RecN{N}, nrecs, cols, colspo
         lineno += lines
 
         # Do not try to parse commented lines.
-        pos, lines = eatcommentlines(str, pos, lastindex(str), commentstring)
+        pos, lines = eatcommentlines(str, pos, lastindex(str), commentchar)
         lineno += lines
         pos > l && return rowno-1
 

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -65,6 +65,7 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 - `spacedelim`: (Bool) parse space-delimited files. `delim` has no effect if true.
 - `quotechar`: character used to quote strings, defaults to `"`
 - `escapechar`: character used to escape quotechar in strings. (could be the same as quotechar)
+- `commentstring`: ignore lines that begin with commentstring
 - `nrows`: number of rows in the file. Defaults to `0` in which case we try to estimate this.
 - `skiplines_begin`: skips specified number of lines at the beginning of the file
 - `header_exists`: boolean specifying whether CSV file contains a header
@@ -149,6 +150,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                  spacedelim=false,
                  quotechar='"',
                  escapechar='"',
+                 commentstring="#",
                  stringtype=String,
                  noresize=false,
                  rowno::Int=1,
@@ -192,6 +194,11 @@ function _csvread_internal(str::AbstractString, delim=',';
         pos, lines = eatnewlines(str, pos)
         lineno += lines
     end
+
+    # Ignore commented lines before the header.
+    pos, lines = eatcommentlines(str, pos, lastindex(str), commentstring)
+    lineno += lines
+
     if header_exists
         merged_colnames, pos = readcolnames(str, opts, pos, colnames)
         lineno += 1
@@ -221,7 +228,8 @@ function _csvread_internal(str::AbstractString, delim=',';
 
     # seed guesses using those from previous file
     guess, pos1 = guesscolparsers(str, canonnames, opts,
-                                  pos, type_detect_rows, colparsers,
+                                  pos, type_detect_rows, 
+                                  colparsers, commentstring,
                                   nastrings, prev_parsers)
     if isempty(canonnames)
         canonnames = Any[1:length(guess);]
@@ -305,7 +313,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     @label retry
     try
         finalrows = parsefill!(str, opts, rec, nrows, cols, colspool,
-                               pos, lineno, rowno, lastindex(str))
+                               pos, lineno, rowno, lastindex(str), commentstring)
         if !noresize
             resizecols(colspool, finalrows)
         end
@@ -454,9 +462,9 @@ function readcolnames(str, opts, pos, colnames)
     colnames_inferred, lineend+1
 end
 
-
 function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
-                       nrows::Int, colparsers, nastrings=NA_STRINGS, prevs=nothing)
+                       nrows::Int, colparsers, commentstring="#", nastrings=NA_STRINGS,
+                       prevs=nothing)
     # Field type guesses
     guess = []
     prevfields = String[]
@@ -464,9 +472,10 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
     givenkeys = !isempty(colparsers) ? first.(collect(optionsiter(colparsers, header))) : []
     for i2=1:nrows
         pos, _ = eatnewlines(str, pos)
-        if pos > lastindex(str)
-            break
-        end
+
+        # Move past commented lines before guessing.
+        pos, _ = eatcommentlines(str, pos, lastindex(str), commentstring)
+        pos > lastindex(str) && break
 
         lineend = getlineend(str, pos)
 
@@ -516,12 +525,19 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
 end
 
 function parsefill!(str::AbstractString, opts, rec::RecN{N}, nrecs, cols, colspool,
-                    pos, lineno, rowno, l=lastindex(str)) where {N}
+                    pos, lineno, rowno, l=lastindex(str), commentstring="#") where {N}
     pos, lines = eatnewlines(str, pos)
     lineno += lines
+
     pos <= l && while true
         prev_j = pos
         lineno += lines
+
+        # Do not try to parse commented lines.
+        pos, lines = eatcommentlines(str, pos, lastindex(str), commentstring)
+        lineno += lines
+        pos > l && return rowno-1
+
         res = tryparsesetindex(rec, str, pos, l, cols, rowno, opts)
         if !issuccess(res)
             pos, fieldpos, colno, err_code = geterror(res)
@@ -537,6 +553,7 @@ function parsefill!(str::AbstractString, opts, rec::RecN{N}, nrecs, cols, colspo
         if pos > l
             return rowno
         end
+
         rowno += 1
         lineno += 1
         if rowno > nrecs

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -150,7 +150,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                  spacedelim=false,
                  quotechar='"',
                  escapechar='"',
-                 commentchar='#',
+                 commentchar=nothing,
                  stringtype=String,
                  noresize=false,
                  rowno::Int=1,
@@ -463,7 +463,7 @@ function readcolnames(str, opts, pos, colnames)
 end
 
 function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
-                       nrows::Int, colparsers, commentchar='#', nastrings=NA_STRINGS,
+                       nrows::Int, colparsers, commentchar=nothing, nastrings=NA_STRINGS,
                        prevs=nothing)
     # Field type guesses
     guess = []
@@ -525,7 +525,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
 end
 
 function parsefill!(str::AbstractString, opts, rec::RecN{N}, nrecs, cols, colspool,
-                    pos, lineno, rowno, l=lastindex(str), commentchar='#') where {N}
+                    pos, lineno, rowno, l=lastindex(str), commentchar=nothing) where {N}
     pos, lines = eatnewlines(str, pos)
     lineno += lines
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -126,7 +126,9 @@ end
 
 # Move past consecutive lines that start with commentchar.
 # Return a tuple of the new pos in str and the amount of comment lines moved past.
-function eatcommentlines(str, i=1, l=lastindex(str), commentchar::Char='#') 
+function eatcommentlines(str, i=1, l=lastindex(str), commentchar::Union{Char, Nothing}=nothing) 
+    commentchar == nothing && return i, 0
+
     count = 0
     while i <= l && str[i] == commentchar
         i = getlineend(str, i)

--- a/src/util.jl
+++ b/src/util.jl
@@ -127,7 +127,7 @@ end
 # Move past consecutive lines that start with commentchar.
 # Return a tuple of the new pos in str and the amount of comment lines moved past.
 function eatcommentlines(str, i=1, l=lastindex(str), commentchar::Union{Char, Nothing}=nothing) 
-    commentchar == nothing && return i, 0
+    commentchar === nothing && return i, 0
 
     count = 0
     while i <= l && str[i] == commentchar

--- a/src/util.jl
+++ b/src/util.jl
@@ -124,11 +124,11 @@ function eatnewlines(str, i=1, l=lastindex(str))
     return i, count
 end
 
-# Move past consecutive lines that start with commentstring.
+# Move past consecutive lines that start with commentchar.
 # Return a tuple of the new pos in str and the amount of comment lines moved past.
-function eatcommentlines(str, i=1, l=lastindex(str), commentstring="#") 
+function eatcommentlines(str, i=1, l=lastindex(str), commentchar::Char='#') 
     count = 0
-    while i <= l && startswith(str[i:l], commentstring)
+    while i <= l && str[i] == commentchar
         i = getlineend(str, i)
         _, i = iterate(str, i)
         i, lines = eatnewlines(str, i)

--- a/src/util.jl
+++ b/src/util.jl
@@ -124,6 +124,19 @@ function eatnewlines(str, i=1, l=lastindex(str))
     return i, count
 end
 
+# Move past consecutive lines that start with commentstring.
+# Return a tuple of the new pos in str and the amount of comment lines moved past.
+function eatcommentlines(str, i=1, l=lastindex(str), commentstring="#") 
+    count = 0
+    while i <= l && startswith(str[i:l], commentstring)
+        i = getlineend(str, i)
+        _, i = iterate(str, i)
+        i, lines = eatnewlines(str, i)
+        count += lines
+    end
+    return i, count
+end
+
 function stripquotes(x)
     x[1] in ('\'', '"') && x[1] == x[end] ?
         strip(x, x[1]) : x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -457,6 +457,72 @@ import TextParse: _csvread
                    a""b"", 1""") == ((["a\"\"b\"\""], [1]), ["x\"\"y\"\"", "z"])
 end
 
+import TextParse: _csvread
+@testset "commentstring" begin
+
+    # First line a comment.
+    str1 = """
+    x,y,z
+    #1,1,1
+    2,2,2
+    """
+
+    @test _csvread(str1) == (([2], [2], [2]), String["x", "y","z"])
+
+    # Last line a comment.
+    str2 = """
+    x,y,z
+    1,1,1
+    #2,2,2
+    """
+
+    @test _csvread(str2) == (([1], [1], [1]), String["x", "y","z"])
+
+    # Multiple comments.
+    str3 = """
+    x,y,z
+    1,1,1
+    #2,2,2
+    #3,3,3
+    #4,4,4
+    5,5,5
+    #6,6,6
+    """
+
+    @test _csvread(str3) == (([1, 5], [1, 5], [1, 5]), String["x", "y","z"])
+
+    # Comments before headers.
+    str4 = """
+    #foo
+    #bar
+    x,y,z
+    1,1,1
+    #2,2,2
+    """
+
+    @test _csvread(str4) == (([1], [1], [1]), String["x", "y","z"])
+
+    # No comments.
+    str5 = """
+    x,y,z
+    1,1,1
+    2,2,2
+    """
+
+    @test _csvread(str5) == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
+
+    # Non-default comment.
+    str6 = """
+    //test
+    x,y,z
+    1,1,1
+    //2,2,2
+    2,2,2
+    """
+
+    @test _csvread(str6, commentstring="//") == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
+end
+
 @testset "skiplines_begin" begin
     str1 = """
     hello

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -467,7 +467,7 @@ import TextParse: _csvread
     2,2,2
     """
 
-    @test _csvread(str1) == (([2], [2], [2]), String["x", "y","z"])
+    @test _csvread(str1, commentchar='#') == (([2], [2], [2]), String["x", "y","z"])
 
     # Last line a comment.
     str2 = """
@@ -476,7 +476,7 @@ import TextParse: _csvread
     #2,2,2
     """
 
-    @test _csvread(str2) == (([1], [1], [1]), String["x", "y","z"])
+    @test _csvread(str2, commentchar='#') == (([1], [1], [1]), String["x", "y","z"])
 
     # Multiple comments.
     str3 = """
@@ -489,7 +489,7 @@ import TextParse: _csvread
     #6,6,6
     """
 
-    @test _csvread(str3) == (([1, 5], [1, 5], [1, 5]), String["x", "y","z"])
+    @test _csvread(str3, commentchar='#') == (([1, 5], [1, 5], [1, 5]), String["x", "y","z"])
 
     # Comments before headers.
     str4 = """
@@ -500,7 +500,7 @@ import TextParse: _csvread
     #2,2,2
     """
 
-    @test _csvread(str4) == (([1], [1], [1]), String["x", "y","z"])
+    @test _csvread(str4, commentchar='#') == (([1], [1], [1]), String["x", "y","z"])
 
     # No comments.
     str5 = """
@@ -509,7 +509,7 @@ import TextParse: _csvread
     2,2,2
     """
 
-    @test _csvread(str5) == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
+    @test _csvread(str5, commentchar='#') == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
 
     # Non-default comment.
     str6 = """
@@ -521,6 +521,20 @@ import TextParse: _csvread
     """
 
     @test _csvread(str6, commentchar='%') == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
+
+    # Do not skip commented lines (commentchar=nothing).
+    str7 = """
+    x,y,z
+    1,1,1
+    #2,2,2
+    """
+
+    # Since we are not skipping commented lines the '#' character is considered 
+    # data. This will force parsing to treat columns with '#'s as String columns.
+    # Here, we verify this behavior.
+    result = _csvread(str7)
+    @test eltype(result[1][1]) == String
+    @test result == ((["1", "#2"], [1, 2], [1, 2]), String["x", "y","z"])
 end
 
 @testset "skiplines_begin" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -458,7 +458,7 @@ import TextParse: _csvread
 end
 
 import TextParse: _csvread
-@testset "commentstring" begin
+@testset "commentchar" begin
 
     # First line a comment.
     str1 = """
@@ -513,14 +513,14 @@ import TextParse: _csvread
 
     # Non-default comment.
     str6 = """
-    //test
+    %test
     x,y,z
     1,1,1
-    //2,2,2
+    %2,2,2
     2,2,2
     """
 
-    @test _csvread(str6, commentstring="//") == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
+    @test _csvread(str6, commentchar='%') == (([1, 2], [1, 2], [1, 2]), String["x", "y","z"])
 end
 
 @testset "skiplines_begin" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -535,6 +535,17 @@ import TextParse: _csvread
     result = _csvread(str7)
     @test eltype(result[1][1]) == String
     @test result == ((["1", "#2"], [1, 2], [1, 2]), String["x", "y","z"])
+
+
+    # Quoted lines commented out.
+    str8 = """
+    a,b,c
+    "the","quick","brown"
+    #"fox","jum\nps","over"
+    "the","lazy","dog"
+    """
+
+    @test_skip _csvread(str8, commentchar='#') == ((["the","the"], ["quick", "lazy"], ["brown","dog"]), String["x", "y","z"])
 end
 
 @testset "skiplines_begin" begin


### PR DESCRIPTION
This PR is an attempt to tackle #54. 

+ Moving past commented lines is implemented as a function `eatcommentline` in util.jl
+ Calls to this function are made in csv.jl
+ Added a `commentstring` param
+ Added tests

Please lemme know if you have any feedback or suggestions on anything that can be improved!

