### PR TITLE
Add support for skipping columns

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -51,7 +51,7 @@ tofield(f::Type, opts, stringarraytype) = tofield(fromtype(f), opts, stringarray
 tofield(f::Type{String}, opts, stringarraytype::Type{StringArray}) = tofield(fromtype(StrRange), opts, stringarraytype)
 tofield(f::Type{String}, opts, stringarraytype::Type{Array}) = tofield(fromtype(String), opts, stringarraytype)
 tofield(f::DateFormat, opts, stringarraytype) = tofield(DateTimeToken(DateTime, f), opts, stringarraytype)
-tofield(f::Nothing, opts, stringarraytype) = Field(SkipToken())
+tofield(f::Nothing, opts, stringarraytype) = Field(SkipToken(Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)))
 
 """
     csvread(file::Union{String,IO}, delim=','; <arguments>...)

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -108,21 +108,13 @@ function _csvread_f(file::AbstractString, delim=','; kwargs...)
     if ext == "gz" # Gzipped
         return open(GzipDecompressorStream, file, "r") do io
             data = read(io)
-            cols, canonnames, parsers, finalrows = _csvread_internal(String(data), delim; filename=file, kwargs...)
-            ((col for col in cols if col!==nothing)...,),
-                [colname for (col, colname) in zip(cols, canonnames) if col!==nothing],
-                parsers,
-                finalrows
+            _csvread_internal(String(data), delim; filename=file, kwargs...)
         end
     else # Otherwise just try to read the file
         return open(file, "r") do io
             data = Mmap.mmap(io)
             try
-                cols, canonnames, parsers, finalrows = _csvread_internal(VectorBackedUTF8String(data), delim; filename=file, kwargs...)
-                ((col for col in cols if col!==nothing)...,),
-                    [colname for (col, colname) in zip(cols, canonnames) if col!==nothing],
-                    parsers,
-                    finalrows
+                _csvread_internal(VectorBackedUTF8String(data), delim; filename=file, kwargs...)
             finally
                 finalize(data)
             end

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -157,7 +157,7 @@ function csvread(files::AbstractVector{T},
     end
 
     resizecols(colspool, nrows)
-    (values(colspool)...,), collect(keys(colspool)), count
+    ((i[2] for i in colspool if i[2]!==nothing)...,), [i[1] for i in colspool if i[2]!==nothing], count
 end
 
 # read CSV in a string

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -73,7 +73,7 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 - `header_exists`: boolean specifying whether CSV file contains a header
 - `nastrings`: strings that are to be considered NA. Defaults to `TextParse.NA_STRINGS`
 - `colnames`: manually specified column names. Could be a vector or a dictionary from Int index (the column) to String column name.
-- `colparsers`: Parsers to use for specified columns. This can be a vector or a dictionary from column name / column index (Int) to a "parser". The simplest parser is a type such as Int, Float64. It can also be a `dateformat"..."`, see [CustomParser](@ref) if you want to plug in custom parsing behavior
+- `colparsers`: Parsers to use for specified columns. This can be a vector or a dictionary from column name / column index (Int) to a "parser". The simplest parser is a type such as Int, Float64. It can also be a `dateformat"..."`, see [CustomParser](@ref) if you want to plug in custom parsing behavior. If you pass `nothing` as the parser for a given column, that column will be skipped
 - `type_detect_rows`: number of rows to use to infer the initial `colparsers` defaults to 20.
 """
 function csvread(file::String, delim=','; kwargs...)

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -141,7 +141,7 @@ function csvread(files::AbstractVector{T},
     count = Int[nrows]
     prev = nrows
     for f in files[2:end]
-        if !isempty(cols) && length(cols[1]) == nrows
+        if !isempty(cols) && length(cols[findfirst(i->i!==nothing, cols)]) == nrows
             n = ceil(Int, nrows * sqrt(2))
             resizecols(colspool, n)
         end
@@ -180,7 +180,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                  #ignore_empty_rows=true,
                  colspool = ColsPool(),
                  nrows = !isempty(colspool) ?
-                     length(first(colspool)[2]) : 0,
+                     length(first(i for i in colspool if i[2]!==nothing)[2]) : 0,
                  prev_parsers = nothing,
                  colparsers=[],
                  filename=nothing,
@@ -298,7 +298,7 @@ function _csvread_internal(str::AbstractString, delim=',';
             c = get(canonnames, i, i)
             f = rec.fields[i]
             if haskey(colspool, c)
-                if eltype(colspool[c]) == fieldtype(f) || (fieldtype(f) <: StrRange && eltype(colspool[c]) <: AbstractString)
+                if eltype(colspool[c]) == fieldtype(f) || (fieldtype(f) <: StrRange && eltype(colspool[c]) <: AbstractString) || colspool[c]===nothing
                     return colspool[c]
                 else
                     try

--- a/src/field.jl
+++ b/src/field.jl
@@ -630,74 +630,18 @@ end
 
 fromtype(::Type{Union{Missing,T}}) where T = NAToken(fromtype(T))
 
-struct SkipToken <: AbstractToken{Nothing}
+struct SkipToken{S} <: AbstractToken{Nothing}
+    inner::S
 end
 
-function tryparsenext(::SkipToken, str, i, len, opts)
-    R = Nullable{Nothing}
-    p = ' '
-    i0 = i
-    if opts.includequotes
-        y = iterate(str, i)
-        if y!==nothing
-            c = y[1]; ii = y[2]
-            if c == opts.quotechar
-                i = ii # advance counter so that
-                       # the while loop doesn't react to opening quote
-            end
-        end
+function tryparsenext(f::SkipToken, str, i, len, opts)
+    x, ii = tryparsenext(f.inner, str, i, len, opts)
+
+    if isnull(x)
+        return Nullable{Nothing}(), ii
+    else
+        return Nullable{Nothing}(nothing), ii
     end
-
-    y2 = iterate(str, i)
-    while y2!==nothing
-        c = y2[1]; ii = y2[2]
-        if opts.spacedelim && (c == ' ' || c == '\t')
-            break
-        elseif !opts.spacedelim && c == opts.endchar
-            if opts.endchar == opts.quotechar
-                # this means we're inside a quoted string
-                if opts.quotechar == opts.escapechar
-                    # sometimes the quotechar is the escapechar
-                    # in that case we need to see the next char
-                    y3 = iterate(str, ii)
-                    if y3===nothing
-                        if opts.includequotes
-                            i=ii
-                        end
-                        break
-                    else
-                        nxt = y3[1]; j = y3[2]
-                        if nxt == opts.quotechar
-                            # the current character is escaping the
-                            # next one
-                            i = j # skip next char as well
-                            p = nxt
-                            y2 = iterate(str, i)
-                            continue
-                        end
-                    end
-                elseif p == opts.escapechar
-                    # previous char escaped this one
-                    i = ii
-                    p = c
-                    y2 = iterate(str, i)
-                    continue
-                end
-            end
-            if opts.includequotes
-                i = ii
-            end
-            break
-        elseif (!opts.includenewlines && isnewline(c))
-            break
-        end
-        i = ii
-        p = c
-
-        y2 = iterate(str, i)
-    end
-
-    return R(nothing), i
 end
 
 ### Field parsing

--- a/src/record.jl
+++ b/src/record.jl
@@ -79,7 +79,7 @@ end
         ii = i
         err_code = PARSE_ERROR
         i > len && @goto error
-
+        
         $(fieldparsers...)
 
         @label done
@@ -97,6 +97,10 @@ end
 
 @inline function setcell!(col::Array{String,1}, i, val::StrRange, str)
     col[i] = alloc_string(str, val)
+    PARSE_SUCCESS
+end
+
+@inline function setcell!(col::Nothing, i, val, str)
     PARSE_SUCCESS
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -654,6 +654,15 @@ end
     @test _csvread(s, spacedelim=true) == ((["a,b", "e"],[1,3]), ["x,y","z"])
 end
 
+@testset "skipfield" begin
+    str1 = """
+    x,y,z
+    1,2,3
+    """
+
+    @test _csvread(str1, colparsers=Dict(2=>nothing)) == (([1], [3]), String["x","z"])
+end
+
 import TextParse: eatwhitespaces
 @testset "custom parser" begin
     floatparser = Numeric(Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -657,10 +657,19 @@ end
 @testset "skipfield" begin
     str1 = """
     x,y,z
-    1,2,3
+    1,2.1,"John"
+    4,5.2,"Sally"
     """
 
-    @test _csvread(str1, colparsers=Dict(2=>nothing)) == (([1], [3]), String["x","z"])
+    @test _csvread(str1, colparsers=Dict(1=>nothing)) == (([2.1,5.2], ["John", "Sally"]), String["y","z"])
+    @test _csvread(str1, colparsers=Dict(2=>nothing)) == (([1,4], ["John", "Sally"]), String["x","z"])
+    @test _csvread(str1, colparsers=Dict(3=>nothing)) == (([1,4], [2.1,5.2]), String["x","y"])
+
+    @test _csvread(str1, colparsers=Dict(1=>nothing,2=>nothing)) == ((["John", "Sally"],), String["z"])
+    @test _csvread(str1, colparsers=Dict(1=>nothing,3=>nothing)) == (([2.1,5.2],), String["y"])
+    @test _csvread(str1, colparsers=Dict(2=>nothing,3=>nothing)) == (([1,4],), String["x"])
+
+    @test _csvread(str1, colparsers=Dict(1=>nothing,2=>nothing,3=>nothing)) == ((), String[])
 end
 
 import TextParse: eatwhitespaces


### PR DESCRIPTION
General idea is that if you specify ``nothing`` for a given column in the ``colparsers`` argument, it will just skip that column and not read it in at all. ~~Still needs some work.~~

- [x] Tests
- [x] ``csvread`` for multiple files needs to drop ``nothing`` columns from return value
- [x] UTF8 optimized version
- [x] Docs
- [x] Double check whether the actual parser is correct

EDIT: Alright, this is ready for review. @shashi, would be great if you could take a look, given that this touches a fair number of places in the code base. @joshday I'm not sure how the general multi file stuff interacts with JuliaDB, so it would probably be good if someone from the JuliaDB side could test this branch with important JuliaDB scenarios. Is that something you might be able to do?

Once this is merged and shipped and we have some real world experiences with it, I plan to tackle the real reason I added this in the first place: in the future, when we come across a column that was detected as not-string, and then mid-way through the parsing we realize it actually is a string, we can use this functionality to _just_ reparse that column as a string. I think that should cover the last remaining case where we fail right now if the column type guessing gets something wrong.