### PR TITLE
just use String(read(f)), not String(Mmap.mmap(f))

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -1,5 +1,4 @@
 using DataStructures
-using Mmap
 
 ismissingtype(T) = Missing <: T
 ismissingeltype(T) = missingtype(eltype(T))
@@ -75,14 +74,8 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 """
 csvread(file::String, delim=','; kwargs...) = _csvread_f(file, delim; kwargs...)[1:2]
 
-function csvread(file::IOStream, delim=','; kwargs...)
-    mmap_data = Mmap.mmap(file)
-    _csvread(String(pointer(mmap_data), length(mmap_data)), delim; kwargs...)
-end
-
 function csvread(buffer::IO, delim=','; kwargs...)
-    mmap_data = read(buffer)
-    _csvread(String(mmap_data), delim; kwargs...)
+    _csvread(String(read(buffer)), delim; kwargs...)
 end
 
 function _csvread(str::AbstractString, delim=','; kwargs...)
@@ -100,7 +93,7 @@ function _csvread_f(file::AbstractString, delim=','; kwargs...)
         end
     else # Otherwise just try to read the file
         return open(file, "r") do io
-            data = Mmap.mmap(io)
+            data = read(io)
             _csvread_internal(String(data), delim; filename=file, kwargs...)
         end
     end


### PR DESCRIPTION
If you are just going to read the whole file and copy it into a string, there is no advantage to `mmap` as far as I can tell.  On my machine, for a 1GB file, the `mmap` version is almost 2x slower, and for a few MB file it is 30% slower.

(This makes sense to me: it's the job of `read` to read the data as quickly as possible.  If `mmap` were the fastest way to do this, then `Base.read` should be patched to use `mmap`.   Memory-mapped files seem mostly useful if you want random access.)

This also fixes a bug where a code path was using the nonexistent `String(pointer, len)` function.   The intended function is apparently `unsafe_string`, but this is not gc-safe unless you do `GC.@preserve` on the object the pointer was taken from, and is not necessary anyway since you can just do `String(mmap_array)`.   This bug was [pointed out on discourse](https://discourse.julialang.org/t/csvfiles-read-file-with-non-standard-extension/18096).