### PR TITLE
Optionally use UInt8 for various chars

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -73,3 +73,7 @@ SUITE["util"]["tryparsenext"]["Percentage"] = @benchmarkable TextParse.tryparsen
 SUITE["util"]["tryparsenext"]["StringToken"] = @benchmarkable TextParse.tryparsenext($(TextParse.StringToken(String)), $somestring,1,$somestringlen, TextParse.default_opts)
 SUITE["util"]["tryparsenext"]["DateTimeToken"] = @benchmarkable TextParse.tryparsenext($tok, $datetimestr,1,$datetimestrlen, $opts)
 SUITE["util"]["tryparsenext"]["QuotedStringToken"] = @benchmarkable TextParse.tryparsenext($(Quoted(String,quotechar='"', escapechar='"')), $somequotedstring)
+
+somefieldstring = " 12,3"
+f = TextParse.fromtype(Int)
+SUITE["util"]["tryparsenext"]["Field"] = @benchmarkable TextParse.tryparsenext($(TextParse.Field(f)), $somefieldstring)

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -170,7 +170,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     if pooledstrings === true
         warn("pooledstrings argument has been removed")
     end
-    opts = LocalOpts(UInt8(delim), spacedelim, quotechar, escapechar, false, false)
+    opts = LocalOpts(isascii(delim) ? UInt8(delim) : delim, spacedelim, quotechar, escapechar, false, false)
     len = lastindex(str)
     pos = firstindex(str)
     rowlength_sum = 0   # sum of lengths of rows, for estimating nrows

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -170,7 +170,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     if pooledstrings === true
         warn("pooledstrings argument has been removed")
     end
-    opts = LocalOpts(delim, spacedelim, quotechar, escapechar, false, false)
+    opts = LocalOpts(UInt8(delim), spacedelim, quotechar, escapechar, false, false)
     len = lastindex(str)
     pos = firstindex(str)
     rowlength_sum = 0   # sum of lengths of rows, for estimating nrows
@@ -645,7 +645,7 @@ function quotedsplit(str, opts, includequotes, i=firstindex(str), l=lastindex(st
     y1 = iterate(str, prevind(str, i))
     y1===nothing && error("Internal error.")
     c = y1[1]; i = y1[2]
-    if c == opts.endchar
+    if c == Char(opts.endchar)
         # edge case where there's a delim at the end of the string
         push!(strs, "")
     end

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -46,7 +46,7 @@ optionsiter(opts::AbstractVector, header) = optionsiter(opts)
 
 tofield(f::AbstractField, opts) = f
 tofield(f::AbstractToken, opts) = Field(f)
-tofield(f::StringToken, opts) = Field(Quoted(f))
+tofield(f::StringToken, opts) = Field(Quoted(f, opts.quotechar, opts.escapechar))
 tofield(f::Type, opts) = tofield(fromtype(f), opts)
 tofield(f::Type{String}, opts) = tofield(fromtype(StrRange), opts)
 tofield(f::DateFormat, opts) = tofield(DateTimeToken(DateTime, f), opts)
@@ -170,7 +170,9 @@ function _csvread_internal(str::AbstractString, delim=',';
     if pooledstrings === true
         warn("pooledstrings argument has been removed")
     end
-    opts = LocalOpts(isascii(delim) ? UInt8(delim) : delim, spacedelim, quotechar, escapechar, false, false)
+    opts = LocalOpts(isascii(delim) ? UInt8(delim) : delim, spacedelim,
+        isascii(quotechar) ? UInt8(quotechar) : quotechar,
+        isascii(escapechar) ? UInt8(escapechar) : escapechar, false, false)
     len = lastindex(str)
     pos = firstindex(str)
     rowlength_sum = 0   # sum of lengths of rows, for estimating nrows
@@ -359,7 +361,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                 col = cols[colidx]
                 f = rec.fields[colidx]
                 name = get(canonnames, colidx, colidx)
-                c = promote_field(s, f, col, err, nastrings, stringtype)
+                c = promote_field(s, f, col, err, nastrings, stringtype, opts)
                 colspool[name] = c[2]
                 c
             end
@@ -397,8 +399,8 @@ function _csvread_internal(str::AbstractString, delim=',';
     cols, canonnames, parsers, finalrows
 end
 
-function promote_field(failed_str, field, col, err, nastrings, stringtype)
-    newtoken = guesstoken(failed_str, field.inner, nastrings)
+function promote_field(failed_str, field, col, err, nastrings, stringtype, opts)
+    newtoken = guesstoken(failed_str, opts, field.inner, nastrings)
     if newtoken == field.inner
         # no need to change
         return field, col
@@ -495,7 +497,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
                 error("previous rows had $(length(guess)) fields but row $i2 has $(length(fields))")
             end
             try
-                guess[j] = guesstoken(fields[j], guess[j], nastrings)
+                guess[j] = guesstoken(fields[j], opts, guess[j], nastrings)
             catch err
                 println(stderr, "Error while guessing a common type for column $j")
                 println(stderr, "new value: $(fields[j]), prev guess was: $(guess[j])")
@@ -630,7 +632,7 @@ function showerrorchar(str, pos, maxchar)
 end
 
 function quotedsplit(str, opts, includequotes, i=firstindex(str), l=lastindex(str))
-    strtok = Quoted(StringToken(String), required=false,
+    strtok = Quoted(StringToken(String), opts.quotechar, opts.escapechar, required=false,
                     includequotes=includequotes)
 
     f = Field(strtok, eoldelim=true)

--- a/src/lib/date-tryparse-internal.jl
+++ b/src/lib/date-tryparse-internal.jl
@@ -15,7 +15,7 @@ Returns a 2-element tuple `(values, pos)`:
 * `pos::Int`: The character index at which parsing stopped.
 """
 @generated function tryparsenext_internal(
-                                          ::Type{T}, str::AbstractString, pos::Int, len::Int, df::DateFormat, endchar='\0', raise::Bool=false,
+                                          ::Type{T}, str::AbstractString, pos::Int, len::Int, df::DateFormat, endchar=UInt('\0'), raise::Bool=false,
 ) where {T<:TimeType}
     letters = character_codes(df)
 
@@ -51,7 +51,7 @@ Returns a 2-element tuple `(values, pos)`:
         unsafe_val = unsafe_get(values)
         $(assign_value_till...)
         if isnull(values)
-            if (pos <= len && str[pos] == endchar) ||
+            if (pos <= len && str[pos] == Char(endchar)) ||
                 num_parsed == $(length(value_names))
                 # finished parsing and found an extra char,
                 # or parsing was terminated by a delimiter

--- a/src/utf8optimizations.jl
+++ b/src/utf8optimizations.jl
@@ -196,7 +196,6 @@ const pre_comp_exp = Float64[10.0^i for i=0:22]
 end
 
 function tryparsenext(f::Field{T}, str::String, i, len, opts::LocalOpts{T_ENDCHAR}) where {T, T_ENDCHAR<:UInt8}
-    @info "HAPPENING"
     R = Nullable{T}
     i > len && @goto error
     if f.ignore_init_whitespace

--- a/src/utf8optimizations.jl
+++ b/src/utf8optimizations.jl
@@ -194,3 +194,69 @@ const pre_comp_exp = Float64[10.0^i for i=0:22]
     @label error
     return R(), i
 end
+
+function tryparsenext(f::Field{T}, str::String, i, len, opts::LocalOpts{T_ENDCHAR}) where {T, T_ENDCHAR<:UInt8}
+    R = Nullable{T}
+    i > len && @goto error
+    if f.ignore_init_whitespace
+        i = eatwhitespaces(str, i, len)
+    end
+    @chk2 res, i = tryparsenext(f.inner, str, i, len, opts)
+
+    if f.ignore_end_whitespace
+        i0 = i
+
+        while i<=len
+            @inbounds b = codeunit(str, i)
+
+            !opts.spacedelim && opts.endchar == 0x09 && b == 0x09 && (i = i+1; @goto done) # 0x09 is \t
+
+            b!=0x20 && b!=0x09 && break
+            i=i+1
+        end
+
+        opts.spacedelim && i > i0 && @goto done
+    end
+    # todo don't ignore whitespace AND spacedelim
+
+    if i > len
+        if f.eoldelim
+            @goto done
+        else
+            @goto error
+        end
+    end
+
+    i>len && error("Internal error.")
+    @inbounds b = codeunit(str, i)
+    opts.spacedelim && (b!=0x20 || b!=0x09) && (i+=1; @goto done)
+    !opts.spacedelim && opts.endchar == b && (i+=1; @goto done)
+
+    if f.eoldelim
+        if b == 0x0d # '\r'
+            i+=1
+            if i<=len
+                @inbounds b = codeunit(str, i)
+                if b == 0x0a # '\n'
+                    i+=1
+                end
+            end
+            @goto done
+        elseif b == 0x0a # '\n'
+            i+=1
+            if i<=len
+                @inbounds b = codeunit(str, i)
+                if b == 0x0d # '\r'
+                    i+=1
+                end
+            end
+            @goto done
+        end
+    end
+
+    @label error
+    return R(), i
+
+    @label done
+    return R(convert(T, res)), i
+end

--- a/src/utf8optimizations.jl
+++ b/src/utf8optimizations.jl
@@ -195,7 +195,7 @@ const pre_comp_exp = Float64[10.0^i for i=0:22]
     return R(), i
 end
 
-function tryparsenext(f::Field{T}, str::String, i, len, opts::LocalOpts{T_ENDCHAR}) where {T, T_ENDCHAR<:UInt8}
+function tryparsenext(f::Field{T}, str::Union{VectorBackedUTF8String, String}, i, len, opts::LocalOpts{T_ENDCHAR}) where {T, T_ENDCHAR<:UInt8}
     R = Nullable{T}
     i > len && @goto error
     if f.ignore_init_whitespace

--- a/src/utf8optimizations.jl
+++ b/src/utf8optimizations.jl
@@ -196,6 +196,7 @@ const pre_comp_exp = Float64[10.0^i for i=0:22]
 end
 
 function tryparsenext(f::Field{T}, str::String, i, len, opts::LocalOpts{T_ENDCHAR}) where {T, T_ENDCHAR<:UInt8}
+    @info "HAPPENING"
     R = Nullable{T}
     i > len && @goto error
     if f.ignore_init_whitespace

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,10 +107,10 @@ using WeakRefStrings
 
     opts = LocalOpts(',', false, '"', '\\', false, false)
     str =  "Owner 2 ”Vicepresident\"\""
-    @test tryparsenext(Quoted(String), str) |> unwrap == (str, lastindex(str)+1)
+    @test tryparsenext(Quoted(String, '"', '\\'), str) |> unwrap == (str, lastindex(str)+1)
     str1 =  "\"Owner 2 ”Vicepresident\"\"\""
-    @test tryparsenext(Quoted(String,quotechar='"', escapechar='"'), str1) |> unwrap == (str, lastindex(str1)+1)
-    @test tryparsenext(Quoted(String), "\"\tx\"") |> unwrap == ("\tx", 5)
+    @test tryparsenext(Quoted(String,'"', '"'), str1) |> unwrap == (str, lastindex(str1)+1)
+    @test tryparsenext(Quoted(String,'"', '\\'), "\"\tx\"") |> unwrap == ("\tx", 5)
     opts = LocalOpts(',', true, '"', '\\', false, false)
     @test tryparsenext(StringToken(String), "x y",1,3, opts) |> unwrap == ("x", 2)
 end
@@ -120,55 +120,55 @@ import TextParse: Quoted, NAToken, Unknown
 @testset "Quoted string parsing" begin
     opts = LocalOpts(',', false, '"', '"', true, true)
 
-    @test tryparsenext(Quoted(String), "\"\"") |> unwrap == ("", 3)
-    @test tryparsenext(Quoted(String), "\"\" ", opts) |> unwrap == ("", 3)
-    @test tryparsenext(Quoted(String), "\"x\"") |> unwrap == ("x", 4)
-    @test tryparsenext(Quoted(String, includequotes=true), "\"x\"") |> unwrap == ("\"x\"", 4)
+    @test tryparsenext(Quoted(String, '"', '"'), "\"\"") |> unwrap == ("", 3)
+    @test tryparsenext(Quoted(String, '"', '"'), "\"\" ", opts) |> unwrap == ("", 3)
+    @test tryparsenext(Quoted(String, '"', '"'), "\"x\"") |> unwrap == ("x", 4)
+    @test tryparsenext(Quoted(String, '"', '"', includequotes=true), "\"x\"") |> unwrap == ("\"x\"", 4)
     str2 =  "\"\"\"\""
-    @test tryparsenext(Quoted(String), str2, opts) |> unwrap == ("\"\"", lastindex(str2)+1)
+    @test tryparsenext(Quoted(String, '"', '"'), str2, opts) |> unwrap == ("\"\"", lastindex(str2)+1)
     str1 =  "\"x”y\"\"\""
-    @test tryparsenext(Quoted(StringToken(String), required=true), "x\"y\"") |> failedat == 1
+    @test tryparsenext(Quoted(StringToken(String), '"', '"', required=true), "x\"y\"") |> failedat == 1
 
-    @test tryparsenext(Quoted(String, escapechar='"'), str1) |> unwrap == ("x”y\"\"", lastindex(str1)+1)
-    @test tryparsenext(Quoted(StringToken(String), escapechar='\\'), "\"x\\\"yz\"") |> unwrap == ("x\\\"yz", 8)
-    @test tryparsenext(Quoted(NAToken(fromtype(Int))), "1") |> unwrap == (1,2)
+    @test tryparsenext(Quoted(String, '"', '"'), str1) |> unwrap == ("x”y\"\"", lastindex(str1)+1)
+    @test tryparsenext(Quoted(StringToken(String), '"', '\\'), "\"x\\\"yz\"") |> unwrap == ("x\\\"yz", 8)
+    @test tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "1") |> unwrap == (1,2)
 
-    t = tryparsenext(Quoted(NAToken(fromtype(Int))), "") |> unwrap
+    t = tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "") |> unwrap
     @test ismissing(t[1])
     @test t[2] == 1
 
-    t = tryparsenext(Quoted(NAToken(fromtype(Int))), "\"\"") |> unwrap
+    t = tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "\"\"") |> unwrap
     @test ismissing(t[1])
     @test t[2] == 3
-    @test tryparsenext(Quoted(NAToken(fromtype(Int))), "\"1\"") |> unwrap == (1, 4)
+    @test tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "\"1\"") |> unwrap == (1, 4)
 
 
-    @test tryparsenext(Quoted(StringToken(String)), "\"abc\"") |> unwrap == ("abc", 6)
-    @test tryparsenext(Quoted(StringToken(String)), "x\"abc\"") |> unwrap == ("x\"abc\"", 7)
-    @test tryparsenext(Quoted(StringToken(String)), "\"a\nbc\"") |> unwrap == ("a\nbc", 7)
-    @test tryparsenext(Quoted(StringToken(String), required=true), "x\"abc\"") |> failedat == 1
-    @test tryparsenext(Quoted(fromtype(Int)), "21") |> unwrap == (21,3)
-    @test tryparsenext(Quoted(NAToken(fromtype(Int))), "21") |> unwrap == (21,3)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"'), "\"abc\"") |> unwrap == ("abc", 6)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"'), "x\"abc\"") |> unwrap == ("x\"abc\"", 7)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"'), "\"a\nbc\"") |> unwrap == ("a\nbc", 7)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"', required=true), "x\"abc\"") |> failedat == 1
+    @test tryparsenext(Quoted(fromtype(Int), '"', '"'), "21") |> unwrap == (21,3)
+    @test tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "21") |> unwrap == (21,3)
 
-    t = tryparsenext(Quoted(NAToken(fromtype(Int))), "") |> unwrap
+    t = tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "") |> unwrap
     @test ismissing(t[1])
     @test t[2] == 1
 
-    t = tryparsenext(Quoted(NAToken(fromtype(Int))), "\"\"") |> unwrap
+    t = tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "\"\"") |> unwrap
     @test ismissing(t[1])
     @test t[2] == 3
 
-    @test tryparsenext(Quoted(NAToken(fromtype(Int))), "\"21\"") |> unwrap == (21, 5)
-    @test ismissing(tryparsenext(Quoted(NAToken(Unknown())), " ") |> unwrap |> first)
+    @test tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "\"21\"") |> unwrap == (21, 5)
+    @test ismissing(tryparsenext(Quoted(NAToken(Unknown()), '"', '"'), " ") |> unwrap |> first)
     opts = LocalOpts(',', false,'"', '"', false, false)
-    @test tryparsenext(Quoted(StringToken(String)), "x,", opts) |> unwrap == ("x", 2)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"'), "x,", opts) |> unwrap == ("x", 2)
 
     # stripspaces
-    @test tryparsenext(Quoted(Percentage()), "\" 10%\",", opts) |> unwrap == (0.1, 7)
-    @test tryparsenext(Quoted(String), "\" 10%\",", opts) |> unwrap == (" 10%", 7)
+    @test tryparsenext(Quoted(Percentage(), '"', '"'), "\" 10%\",", opts) |> unwrap == (0.1, 7)
+    @test tryparsenext(Quoted(String, '"', '"'), "\" 10%\",", opts) |> unwrap == (" 10%", 7)
     opts = LocalOpts(',', true,'"', '"', false, false)
-    @test tryparsenext(Quoted(StringToken(String)), "\"x y\" y", opts) |> unwrap == ("x y", 6)
-    @test tryparsenext(Quoted(StringToken(String)), "x y", opts) |> unwrap == ("x", 2)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"'), "\"x y\" y", opts) |> unwrap == ("x y", 6)
+    @test tryparsenext(Quoted(StringToken(String), '"', '"'), "x y", opts) |> unwrap == ("x", 2)
 end
 
 @testset "NA parsing" begin
@@ -295,53 +295,54 @@ end
 
 import TextParse: guesstoken, Unknown, Numeric, DateTimeToken, StrRange
 @testset "guesstoken" begin
+    opts = LocalOpts(UInt8(','), false, UInt8('"'), UInt8('"'), false, false)
     # Test null values
-    @test guesstoken("", Unknown()) == NAToken(Unknown())
-    @test guesstoken("null", Unknown()) == NAToken(Unknown())
-    @test guesstoken("", NAToken(Unknown())) == NAToken(Unknown())
-    @test guesstoken("null", NAToken(Unknown())) == NAToken(Unknown())
+    @test guesstoken("", opts, Unknown()) == NAToken(Unknown())
+    @test guesstoken("null", opts, Unknown()) == NAToken(Unknown())
+    @test guesstoken("", opts, NAToken(Unknown())) == NAToken(Unknown())
+    @test guesstoken("null", opts, NAToken(Unknown())) == NAToken(Unknown())
 
     # Test NA
-    @test guesstoken("1", NAToken(Unknown())) == NAToken(Numeric(Int))
-    @test guesstoken("1", NAToken(Numeric(Int))) == NAToken(Numeric(Int))
-    @test guesstoken("", NAToken(Numeric(Int))) == NAToken(Numeric(Int))
-    @test guesstoken("1%", NAToken(Unknown())) == NAToken(Percentage())
+    @test guesstoken("1", opts, NAToken(Unknown())) == NAToken(Numeric(Int))
+    @test guesstoken("1", opts, NAToken(Numeric(Int))) == NAToken(Numeric(Int))
+    @test guesstoken("", opts, NAToken(Numeric(Int))) == NAToken(Numeric(Int))
+    @test guesstoken("1%", opts, NAToken(Unknown())) == NAToken(Percentage())
 
     # Test non-null numeric
-    @test guesstoken("1", Unknown()) == Numeric(Int)
-    @test guesstoken("1", Numeric(Int)) == Numeric(Int)
-    @test guesstoken("", Numeric(Int)) == NAToken(Numeric(Int))
-    @test guesstoken("1.0", Numeric(Int)) == Numeric(Float64)
+    @test guesstoken("1", opts, Unknown()) == Numeric(Int)
+    @test guesstoken("1", opts, Numeric(Int)) == Numeric(Int)
+    @test guesstoken("", opts, Numeric(Int)) == NAToken(Numeric(Int))
+    @test guesstoken("1.0", opts, Numeric(Int)) == Numeric(Float64)
 
     # Test strings
-    @test guesstoken("x", Unknown()) == StringToken(StrRange)
+    @test guesstoken("x", opts, Unknown()) == StringToken(StrRange)
 
     # Test nullable to string
-    @test guesstoken("x", NAToken(Unknown())) == StringToken(StrRange)
+    @test guesstoken("x", opts, NAToken(Unknown())) == StringToken(StrRange)
 
     # Test string to non-null (short circuit)
-    @test guesstoken("1", StringToken(StrRange)) == StringToken(StrRange)
+    @test guesstoken("1", opts, StringToken(StrRange)) == StringToken(StrRange)
 
     # Test quoting
-    @test guesstoken("\"1\"", Unknown()) == Quoted(Numeric(Int))
-    @test guesstoken("\"1\"", Quoted(Numeric(Int))) == Quoted(Numeric(Int))
+    @test guesstoken("\"1\"", opts, Unknown()) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"1\"", opts, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
 
     # Test quoting with Nullable tokens
-    @test guesstoken("\"\"", Quoted(Unknown())) == Quoted(NAToken(Unknown()))
-    @test guesstoken("\"\"", Quoted(NAToken(Unknown()))) == Quoted(NAToken(Unknown()))
-    @test guesstoken("\"\"", Quoted(Numeric(Int))) == Quoted(NAToken(Numeric(Int)))
-    @test guesstoken("\"\"", Unknown()) == Quoted(NAToken(Unknown()))
-    @test guesstoken("\"\"", Numeric(Int)) == Quoted(NAToken(Numeric(Int)))
-    @test guesstoken("", Quoted(Numeric(Int))) == Quoted(NAToken(Numeric(Int)))
-    @test guesstoken("", Quoted(NAToken(Numeric(Int)))) == Quoted(NAToken(Numeric(Int)))
-    @test guesstoken("1", Quoted(NAToken(Numeric(Int)))) == Quoted(NAToken(Numeric(Int)))
-    @test guesstoken("\"1\"", Quoted(NAToken(Numeric(Int)))) == Quoted(NAToken(Numeric(Int)))
+    @test guesstoken("\"\"", opts, Quoted(Unknown(), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, Unknown()) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, Numeric(Int)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("", opts, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("", opts, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("1", opts, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"1\"", opts, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
 
     # Test DateTime detection:
-    tok = guesstoken("2016-01-01 10:10:10.10", Unknown())
+    tok = guesstoken("2016-01-01 10:10:10.10", opts, Unknown())
     @test tok == DateTimeToken(DateTime, dateformat"yyyy-mm-dd HH:MM:SS.s")
-    @test guesstoken("2016-01-01 10:10:10.10", tok) == tok
-    @test guesstoken("2016-01-01 10:10:10.10", Quoted(NAToken(Unknown()))) == Quoted(NAToken(tok))
+    @test guesstoken("2016-01-01 10:10:10.10", opts, tok) == tok
+    @test guesstoken("2016-01-01 10:10:10.10", opts, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(tok), opts.quotechar, opts.escapechar)
 end
 
 import TextParse: guesscolparsers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,6 +205,26 @@ import TextParse: Field
     @test tryparsenext(Field(f,eoldelim=true), " 12\n", 1, 4, opts) |> unwrap == (12,5)
     @test tryparsenext(Field(f,eoldelim=true), " 12\n\r\n", 1, 5, opts) |> unwrap == (12,6)
     @test tryparsenext(Field(f,eoldelim=true), " 12") |> unwrap == (12,4)
+
+    # Also test AbstractString variant
+    @test tryparsenext(Field(f), SubString("12,3",1)) |> unwrap == (12, 4)
+    @test tryparsenext(Field(f), SubString("12 ,3",1)) |> unwrap == (12, 5)
+    @test tryparsenext(Field(f), SubString(" 12 ,3",1)) |> unwrap == (12, 6)
+    opts = LocalOpts('\t', false, 'x','x',true,false)
+    @test tryparsenext(Field(f), SubString("12\t3",1), 1, 4, opts) |> unwrap == (12, 4)
+    @test tryparsenext(Field(f), SubString("12 \t3",1), 1, 5, opts) |> unwrap == (12, 5)
+    @test tryparsenext(Field(f), SubString(" 12 \t 3",1), 1, 6, opts) |> unwrap == (12, 6)
+    opts = LocalOpts('\t', true, 'x','x',true,false)
+    @test tryparsenext(Field(f), SubString(" 12 3",1), 1, 5, opts) |> unwrap == (12, 5)
+    @test tryparsenext(Field(f, ignore_end_whitespace=false), SubString(" 12 \t 3",1), 1,6, opts) |> unwrap == (12, 5)
+    opts = LocalOpts(' ', false, 'x','x',false, false)
+    @test tryparsenext(Field(f,ignore_end_whitespace=false), SubString("12 3",1), 1,4,opts) |> unwrap == (12, 4)
+#    @test tryparsenext(Field(f,ignore_end_whitespace=false), "12 \t3", 1,5,opts) |> failedat == 3
+    opts = LocalOpts('\t', false, 'x','x',false, false)
+    @test tryparsenext(Field(f,ignore_end_whitespace=false), SubString(" 12\t 3",1), 1, 6, opts) |> unwrap == (12,5)
+    @test tryparsenext(Field(f,eoldelim=true), SubString(" 12\n",1), 1, 4, opts) |> unwrap == (12,5)
+    @test tryparsenext(Field(f,eoldelim=true), SubString(" 12\n\r\n",1), 1, 5, opts) |> unwrap == (12,6)
+    @test tryparsenext(Field(f,eoldelim=true), SubString(" 12",1)) |> unwrap == (12,4)
 end
 
 


### PR DESCRIPTION
Before I go on with this, I wanted to get some feedback whether folks are ok with this. If we limit things like ``delim`` to ASCII characters, we can speed up things by quite a bit again. I tested this branch with my comprehensive test suite, and while I don't remember the precise improvement, it was pretty sizable.

If folks are ok with that, I would probably also change some of the other special characters to ASCII only, which should give us a bit more performance, and then it would be ready to merge.

@shashi any thoughts?