### PR TITLE
Estimate nrows better

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -257,8 +257,8 @@ function _csvread_internal(str::AbstractString, delim=',';
     current_record[] = rec
 
     if nrows == 0
-        # just an estimate, with some margin
-        nrows = ceil(Int, pos1/max(1, lineno) * sqrt(2))
+        # just an estimate, with some margin        
+        nrows = ceil(Int, (len-pos) / ((pos1-pos)/max(1, type_detect_rows)) * sqrt(2))
     end
 
     if isempty(colspool)


### PR DESCRIPTION
The old version vastly underestimated the row count for large files, and that led to a lot of reallocations.

This now computes how many bytes are used per row in the rows that are detect for type detection, and then uses that to estimate the total rows based on the file length.

And then it multiplies it by ``sqrt(2)`` as a margin. The idea here is that it will over allocate a bit of memory, but then hopefully no increase in the buffers is needed after that.

This also makes a big difference to parsing speeds.