### PR TITLE
WIP Check for overflow during Int parsing

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -103,6 +103,7 @@ end
         y2===nothing && break
         d = y2[1]; i = y2[2]
         r = r*ten + d
+        r < 0 && return R(), i
     end
     return R(convert(T, r)), i
 end


### PR DESCRIPTION
Fixes #79.

Is this good enough? I'm not sure... I kind of think it should detect all overflow, but I'm not sure...

If it does detect it, then right now what happens is that I think it "widens" the column type to ``Float64``. Is that what we want? I'm also not sure... We could also just throw an error... I think ideally the behavior would depend on whether the user explicitly set a column type (in which case we should throw an error), or whether the column type was guessed, in which case we can widen, if possible.

I think for now my main concern is that we catch this and do something, the current situation just seems a bad bug. So I'd be ok if we for now widen to ``Float64``, and then later come up with some better tactic.

This PR does have a performance impact:

On ``master``:
````
julia> @time csvread("warmup_uniform_data_int64.csv");
  1.417349 seconds (7.60 k allocations: 215.617 MiB, 10.74% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.363587 seconds (7.60 k allocations: 215.617 MiB, 10.64% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.362483 seconds (7.60 k allocations: 215.617 MiB, 10.99% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.348228 seconds (7.60 k allocations: 215.617 MiB, 11.18% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.393110 seconds (7.60 k allocations: 215.617 MiB, 10.83% gc time)
````

This PR:
````
julia> @time csvread("warmup_uniform_data_int64.csv");
  1.470897 seconds (7.60 k allocations: 215.617 MiB, 10.86% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.513223 seconds (7.60 k allocations: 215.617 MiB, 10.06% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.448371 seconds (7.60 k allocations: 215.617 MiB, 10.31% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.536717 seconds (7.60 k allocations: 215.617 MiB, 13.18% gc time)

julia> @time csvread("warmup_uniform_data_int64.csv");
  1.334138 seconds (7.60 k allocations: 215.617 MiB)
````