### PR TITLE
Check for overflow during Int parsing, take 2

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,17 @@ import TextParse: fromtype, Percentage
     @test parsed_floats == floats
 end
 
+@testset "Int parsing" begin
+    @test tryparsenext(fromtype(Int64), "1", 1, 1) |> unwrap == (1, 2)
+    @test tryparsenext(fromtype(Int64), "01", 1, 2) |> unwrap == (1, 3)
+    @test tryparsenext(fromtype(Int64), "0001", 1, 4) |> unwrap == (1, 5)
+    @test tryparsenext(fromtype(Int64), "123", 1, 3) |> unwrap == (123, 4)
+    @test tryparsenext(fromtype(Int64), "00123", 1, 5) |> unwrap == (123, 6)
+    @test tryparsenext(fromtype(Int64), "9223372036854775807", 1, 19) |> unwrap == (9223372036854775807, 20)
+    @test tryparsenext(fromtype(Int64), "9223372036854775808", 1, 19) |> failedat == 1
+    @test tryparsenext(fromtype(Int64), "19223372036854775808", 1, 20) |> failedat == 1
+
+end
 
 import TextParse: StringToken
 using WeakRefStrings


### PR DESCRIPTION
Fixes #79.

This is an alternative approach to the one taken in #96. It performs better because it moves the branch outside of the loop.

I also tried @KristofferC's suggestion to do a string comparison when the number of digits indicate that we might have an overflow. That performed horrible, but really only because the string comparison implementation it used is the super generic one that iterates through the strings. I'm sure one could write a proper string comparison that didn't have those issues.

In any case, for now this seems simpler and less work, performance seems ok, and I think it fixes the bug. So my vote would be to merge this for now (if folks agree that this actually fixes the issue, after you reviewed it).

AND THEN, I would actually like to rewrite the whole int parsing story based on the at absolutely amazing video @KristofferC shared! That was awesome, and suggests that there is still a lot of room for improvement. But, that will be more work, and for now I think we should mainly get the bug fixed.