### PR TITLE
Fix escaped strings handling

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -44,12 +44,13 @@ end
 
 optionsiter(opts::AbstractVector, header) = optionsiter(opts)
 
-tofield(f::AbstractField, opts) = f
-tofield(f::AbstractToken, opts) = Field(f)
-tofield(f::StringToken, opts) = Field(Quoted(f, opts.quotechar, opts.escapechar))
-tofield(f::Type, opts) = tofield(fromtype(f), opts)
-tofield(f::Type{String}, opts) = tofield(fromtype(StrRange), opts)
-tofield(f::DateFormat, opts) = tofield(DateTimeToken(DateTime, f), opts)
+tofield(f::AbstractField, opts, stringarraytype) = f
+tofield(f::AbstractToken, opts, stringarraytype) = Field(f)
+tofield(f::StringToken, opts, stringarraytype) = Field(Quoted(f, opts.quotechar, opts.escapechar))
+tofield(f::Type, opts, stringarraytype) = tofield(fromtype(f), opts, stringarraytype)
+tofield(f::Type{String}, opts, stringarraytype::Type{StringArray}) = tofield(fromtype(StrRange), opts, stringarraytype)
+tofield(f::Type{String}, opts, stringarraytype::Type{Array}) = tofield(fromtype(String), opts, stringarraytype)
+tofield(f::DateFormat, opts, stringarraytype) = tofield(DateTimeToken(DateTime, f), opts, stringarraytype)
 
 """
     csvread(file::Union{String,IO}, delim=','; <arguments>...)
@@ -235,7 +236,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     # seed guesses using those from previous file
     guess, pos1 = guesscolparsers(str, canonnames, opts,
                                   pos, type_detect_rows, colparsers,
-                                  nastrings, prev_parsers)
+                                  stringarraytype, nastrings, prev_parsers)
     if isempty(canonnames)
         canonnames = Any[1:length(guess);]
     end
@@ -247,7 +248,7 @@ function _csvread_internal(str::AbstractString, delim=',';
         if !(fieldtype(v) <: StringLike) && prev_parsers !== nothing && !haskey(colspool, c)
             v = isa(v, NAToken) ? v : NAToken(v)
         end
-        p = tofield(v, opts)
+        p = tofield(v, opts, stringarraytype)
         guess[i] = p
     end
 
@@ -268,7 +269,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     current_record[] = rec
 
     if nrows == 0
-        # just an estimate, with some margin        
+        # just an estimate, with some margin
         nrows = ceil(Int, (len-pos) / ((pos1-pos)/max(1, type_detect_rows)) * sqrt(2))
     end
 
@@ -409,7 +410,7 @@ function _csvread_internal(str::AbstractString, delim=',';
 end
 
 function promote_field(failed_str, field, col, err, nastrings, stringtype, stringarraytype, opts)
-    newtoken = guesstoken(failed_str, opts, field.inner, nastrings)
+    newtoken = guesstoken(failed_str, opts, field.inner, nastrings, stringarraytype)
     if newtoken == field.inner
         # no need to change
         return field, col
@@ -480,7 +481,7 @@ end
 
 
 function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
-                       nrows::Int, colparsers, nastrings=NA_STRINGS, prevs=nothing)
+                       nrows::Int, colparsers, stringarraytype, nastrings=NA_STRINGS, prevs=nothing)
     # Field type guesses
     guess = []
     prevfields = String[]
@@ -517,7 +518,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
                 error("previous rows had $(length(guess)) fields but row $i2 has $(length(fields))")
             end
             try
-                guess[j] = guesstoken(fields[j], opts, guess[j], nastrings)
+                guess[j] = guesstoken(fields[j], opts, guess[j], nastrings, stringarraytype)
             catch err
                 println(stderr, "Error while guessing a common type for column $j")
                 println(stderr, "new value: $(fields[j]), prev guess was: $(guess[j])")
@@ -534,7 +535,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
 
     # override guesses with user request
     for (i, v) in optionsiter(colparsers, header)
-        guess[i] = tofield(v, opts)
+        guess[i] = tofield(v, opts, stringarraytype)
     end
     guess, pos
 end
@@ -654,7 +655,7 @@ end
 function quotedsplit(str, opts, includequotes, i=firstindex(str), l=lastindex(str))
     strtok = Quoted(StringToken(String), opts.quotechar, opts.escapechar, required=false,
                     includequotes=includequotes)
-                    
+
     f = Field(strtok, eoldelim=true)
     strs = String[]
     if l == 0

--- a/src/field.jl
+++ b/src/field.jl
@@ -398,7 +398,7 @@ end
 end
 
 @inline function _substring(::Type{T}, str, i, j, escapecount, escapechar, quotechar, includequotes) where {T<:SubString}
-    escapecount > 0 && error("Not yet handled 2")
+    escapecount > 0 && error("Not yet handled.")
     T(str, i, thisind(j))
 end
 
@@ -413,7 +413,7 @@ end
 end
 
 @inline function _substring(::Type{<:WeakRefString}, str, i, j, escapecount, escapechar, quotechar, includequotes)
-    escapecount > 0 && error("Not yet handled 3")
+    escapecount > 0 && error("Not yet handled.")
     WeakRefString(convert(Ptr{UInt8}, pointer(str, i)), j - i + 1)
 end
 

--- a/src/field.jl
+++ b/src/field.jl
@@ -393,7 +393,7 @@ end
         end
         return String(take!(buf))
     else
-        return String(str[i:thisind(str, j)])
+        return unsafe_string(pointer(str, i), j-i+1)
     end
 end
 

--- a/src/field.jl
+++ b/src/field.jl
@@ -365,23 +365,23 @@ function tryparsenext(s::StringToken{T}, str, i, len, opts) where {T}
         y2 = iterate(str, i)
     end
 
-    return R(_substring(T, str, i0, i-1, escapecount, opts.escapechar, opts.quotechar, opts.includequotes)), i
+    return R(_substring(T, str, i0, i-1, escapecount, opts)), i
 end
 
-@inline function _substring(::Type{String}, str, i, j, escapecount, escapechar, quotechar, includequotes)
+@inline function _substring(::Type{String}, str, i, j, escapecount, opts)
     if escapecount > 0
         buf = IOBuffer(sizehint=j-i+1-escapecount)
         cur_i = i
         c = str[cur_i]
-        if includequotes && c==Char(quotechar)
+        if opts.includequotes && c==Char(opts.quotechar)
             print(buf, c)
             cur_i = nextind(str, cur_i)
         end
         while cur_i <= j
             c = str[cur_i]
-            if c == Char(escapechar)
+            if c == Char(opts.escapechar)
                 next_i = nextind(str, cur_i)
-                if next_i <= j && str[next_i] == Char(quotechar)
+                if next_i <= j && str[next_i] == Char(opts.quotechar)
                     print(buf, str[next_i])
                     cur_i = next_i
                 else
@@ -398,7 +398,7 @@ end
     end
 end
 
-@inline function _substring(::Type{T}, str, i, j, escapecount, escapechar, quotechar, includequotes) where {T<:SubString}
+@inline function _substring(::Type{T}, str, i, j, escapecount, opts) where {T<:SubString}
     escapecount > 0 && error("Not yet handled.")
     T(str, i, thisind(j))
 end
@@ -409,11 +409,11 @@ fromtype(::Type{StrRange}) = StringToken(StrRange)
     unsafe_string(pointer(str, 1 + r.offset), r.length)
 end
 
-@inline function _substring(::Type{StrRange}, str, i, j, escapecount, escapechar, quotechar, includequotes)
+@inline function _substring(::Type{StrRange}, str, i, j, escapecount, opts)
     StrRange(i - 1, j - i + 1, escapecount)
 end
 
-@inline function _substring(::Type{<:WeakRefString}, str, i, j, escapecount, escapechar, quotechar, includequotes)
+@inline function _substring(::Type{<:WeakRefString}, str, i, j, escapecount, opts)
     escapecount > 0 && error("Not yet handled.")
     WeakRefString(convert(Ptr{UInt8}, pointer(str, i)), j - i + 1)
 end

--- a/src/field.jl
+++ b/src/field.jl
@@ -314,7 +314,7 @@ function tryparsenext(s::StringToken{T}, str, i, len, opts) where {T}
     while y2!==nothing
         c = y2[1]; ii = y2[2]
 
-        if p==opts.escapechar
+        if p==Char(opts.escapechar)
             escapecount += 1
         end
 
@@ -372,15 +372,15 @@ end
         buf = IOBuffer(sizehint=j-i+1-escapecount)
         cur_i = i
         c = str[cur_i]
-        if includequotes && c==quotechar
+        if includequotes && c==Char(quotechar)
             print(buf, c)
             cur_i = nextind(str, cur_i)
         end
         while cur_i <= j
             c = str[cur_i]
-            if c == escapechar
+            if c == Char(escapechar)
                 next_i = nextind(str, cur_i)
-                if next_i <= j && str[next_i] == quotechar
+                if next_i <= j && str[next_i] == Char(quotechar)
                     print(buf, str[next_i])
                     cur_i = next_i
                 else

--- a/src/field.jl
+++ b/src/field.jl
@@ -364,16 +364,24 @@ function tryparsenext(s::StringToken{T}, str, i, len, opts) where {T}
         y2 = iterate(str, i)
     end
 
-    return R(_substring(T, str, i0, i-1, escapecount, opts.escapechar)), i
+    return R(_substring(T, str, i0, i-1, escapecount, opts.escapechar, opts.quotechar)), i
 end
 
-@inline function _substring(::Type{String}, str, i, j, escapecount, escapechar)
+@inline function _substring(::Type{String}, str, i, j, escapecount, escapechar, quotechar)
     if escapecount > 0
         buf = IOBuffer()
         cur_i = i
-        while cur_i < j
+        while cur_i <= j
             c = str[cur_i] 
-            if c != escapechar
+            if c == escapechar
+                next_i = nextind(str, cur_i)
+                if next_i <= j && str[next_i] == quotechar
+                    print(buf, str[next_i])
+                    cur_i = next_i
+                else
+                    print(buf, c)
+                end
+            else
                 print(buf, c)
             end
             cur_i = nextind(str, cur_i)
@@ -384,7 +392,7 @@ end
     end
 end
 
-@inline function _substring(::Type{T}, str, i, j, escapecount, escapechar) where {T<:SubString}
+@inline function _substring(::Type{T}, str, i, j, escapecount, escapechar, quotechar) where {T<:SubString}
     escapecount > 0 && error("Not yet handled 2")
     T(str, i, thisind(j))
 end
@@ -395,11 +403,11 @@ fromtype(::Type{StrRange}) = StringToken(StrRange)
     unsafe_string(pointer(str, 1 + r.offset), r.length)
 end
 
-@inline function _substring(::Type{StrRange}, str, i, j, escapecount, escapechar)
+@inline function _substring(::Type{StrRange}, str, i, j, escapecount, escapechar, quotechar)
     StrRange(i - 1, j - i + 1, escapecount)
 end
 
-@inline function _substring(::Type{<:WeakRefString}, str, i, j, escapecount, escapechar)
+@inline function _substring(::Type{<:WeakRefString}, str, i, j, escapecount, escapechar, quotechar)
     escapecount > 0 && error("Not yet handled 3")
     WeakRefString(convert(Ptr{UInt8}, pointer(str, i)), j - i + 1)
 end

--- a/src/field.jl
+++ b/src/field.jl
@@ -295,6 +295,7 @@ show(io::IO, c::StringToken) = print(io, "<string>")
 fromtype(::Type{S}) where {S<:AbstractString} = StringToken(S)
 
 function tryparsenext(s::StringToken{T}, str, i, len, opts) where {T}
+    inside_quoted_strong = Char(opts.endchar) == Char(opts.quotechar)
     escapecount = 0
     R = Nullable{T}
     p = ' '
@@ -314,14 +315,14 @@ function tryparsenext(s::StringToken{T}, str, i, len, opts) where {T}
     while y2!==nothing
         c = y2[1]; ii = y2[2]
 
-        if p==Char(opts.escapechar)
+        if inside_quoted_strong && p==Char(opts.escapechar)
             escapecount += 1
         end
 
         if opts.spacedelim && (c == ' ' || c == '\t')
             break
         elseif !opts.spacedelim && c == Char(opts.endchar)
-            if Char(opts.endchar) == Char(opts.quotechar)
+            if inside_quoted_strong
                 # this means we're inside a quoted string
                 if Char(opts.quotechar) == Char(opts.escapechar)
                     # sometimes the quotechar is the escapechar

--- a/src/field.jl
+++ b/src/field.jl
@@ -146,10 +146,10 @@ const pre_comp_exp_double = Double64[Double64(10.0)^i for i=0:308]
     f = Float64(f1)
     r = f1 - Int64(f) # get the remainder
     x = Double64(f) + Double64(r)
-  
+
     maxexp = 308
     minexp = -256
-  
+
     if exp >= 0
         x *= pre_comp_exp_double[exp+1]
     else
@@ -211,7 +211,7 @@ end
     y3 = iterate(str, i)
     if y3!==nothing && _is_e(str, i)
         i = y3[2]
-    
+
         y4 = iterate(str, i)
         if y4!==nothing
             enegate = false
@@ -266,7 +266,7 @@ function tryparsenext(::Percentage, str, i, len, opts)
         # parse away the % char
         ii = eatwhitespaces(str, ii, len)
         y = iterate(str, ii)
-        if y===nothing 
+        if y===nothing
             return Nullable{Float64}(), ii # failed to parse %
         else
             c = y[1]; k = y[2]
@@ -369,15 +369,15 @@ end
 
 @inline function _substring(::Type{String}, str, i, j, escapecount, escapechar, quotechar, includequotes)
     if escapecount > 0
-        buf = IOBuffer()
+        buf = IOBuffer(sizehint=j-i+1-escapecount)
         cur_i = i
-        c = str[cur_i] 
+        c = str[cur_i]
         if includequotes && c==quotechar
             print(buf, c)
             cur_i = nextind(str, cur_i)
         end
         while cur_i <= j
-            c = str[cur_i] 
+            c = str[cur_i]
             if c == escapechar
                 next_i = nextind(str, cur_i)
                 if next_i <= j && str[next_i] == quotechar

--- a/src/record.jl
+++ b/src/record.jl
@@ -96,7 +96,7 @@ end
 end
 
 @inline Base.@propagate_inbounds function setcell!(col::StringVector, i, val::StrRange, str)
-    val.escapecount>0 && error("Not yet implemented")
+    val.escapecount>0 && @debug("Not yet implemented")
     col[i] = WeakRefString(pointer(str, val.offset + 1), val.length)
     PARSE_SUCCESS
 end

--- a/src/record.jl
+++ b/src/record.jl
@@ -95,12 +95,6 @@ end
     PARSE_SUCCESS
 end
 
-@inline function setcell!(col::Array{String,1}, i, val::StrRange, str)
-    val.escapecount>0 && error("Not yet implemented")
-    col[i] = alloc_string(str, val)
-    PARSE_SUCCESS
-end
-
 @inline Base.@propagate_inbounds function setcell!(col::StringVector, i, val::StrRange, str)
     val.escapecount>0 && error("Not yet implemented")
     col[i] = WeakRefString(pointer(str, val.offset + 1), val.length)

--- a/src/record.jl
+++ b/src/record.jl
@@ -96,11 +96,13 @@ end
 end
 
 @inline function setcell!(col::Array{String,1}, i, val::StrRange, str)
+    val.escapecount>0 && error("Not yet implemented")
     col[i] = alloc_string(str, val)
     PARSE_SUCCESS
 end
 
 @inline Base.@propagate_inbounds function setcell!(col::StringVector, i, val::StrRange, str)
+    val.escapecount>0 && error("Not yet implemented")
     col[i] = WeakRefString(pointer(str, val.offset + 1), val.length)
     PARSE_SUCCESS
 end

--- a/src/record.jl
+++ b/src/record.jl
@@ -96,7 +96,7 @@ end
 end
 
 @inline Base.@propagate_inbounds function setcell!(col::StringVector, i, val::StrRange, str)
-    val.escapecount>0 && @debug("Not yet implemented")
+    # TODO Properly handle the val.escapecount>0 case
     col[i] = WeakRefString(pointer(str, val.offset + 1), val.length)
     PARSE_SUCCESS
 end

--- a/src/utf8optimizations.jl
+++ b/src/utf8optimizations.jl
@@ -319,6 +319,80 @@ function tryparsenext(q::Quoted{T,S,<:UInt8,<:UInt8}, str::Union{VectorBackedUTF
     return Nullable{T}(), i
 end
 
+@inline function isnewline(b::UInt8)
+    b == UInt8(10) || b == UInt8(13)
+end
+
+function tryparsenext(s::StringToken{T}, str::Union{VectorBackedUTF8String, String}, i, len, opts::LocalOpts{<:UInt8,<:UInt8,<:UInt8}) where {T}
+    len = ncodeunits(str)
+    inside_quoted_strong = opts.endchar == opts.quotechar
+    escapecount = 0
+    R = Nullable{T}
+    p = UInt8(0)
+    i0 = i
+    if opts.includequotes
+        if i<=len
+            @inbounds b = codeunit(str, i)
+            if b==opts.quotechar
+                # advance counter so that
+                # the while loop doesn't react to opening quote
+                i += 1
+            end
+        end
+    end
+
+    while i<=len
+        @inbounds b = codeunit(str, i)
+        ii = i + 1
+
+        if inside_quoted_strong && p==opts.escapechar
+            escapecount += 1
+        end
+
+        if opts.spacedelim && (b == UInt8(32) || b == UInt8(9)) # 32 = ' ' and 9 = '\t'
+            break
+        elseif !opts.spacedelim && b == opts.endchar
+            if inside_quoted_strong
+                # this means we're inside a quoted string
+                if opts.quotechar == opts.escapechar
+                    # sometimes the quotechar is the escapechar
+                    # in that case we need to see the next char
+                    if ii > len
+                        if opts.includequotes
+                            i=ii
+                        end
+                        break
+                    else
+                        @inbounds next_b = codeunit(str, ii)
+                        if next_b == opts.quotechar
+                            # the current character is escaping the
+                            # next one
+                            i = ii + 1 # skip next char as well
+                            p = next_b
+                            continue
+                        end
+                    end
+                elseif p == opts.escapechar
+                    # previous char escaped this one
+                    i = ii
+                    p = b
+                    continue
+                end
+            end
+            if opts.includequotes
+                i = ii
+            end
+            break
+        elseif (!opts.includenewlines && isnewline(b))
+            break
+        end
+        i = ii
+        p = b
+    end
+
+    return R(_substring(T, str, i0, i-1, escapecount, opts)), i
+end
+
 @inline function _substring(::Type{String}, str::Union{VectorBackedUTF8String, String}, i, j, escapecount, opts::LocalOpts{<:UInt8,<:UInt8,<:UInt8})
     if escapecount > 0
         buffer = Vector{UInt8}(undef, j-i+1-escapecount)

--- a/src/util.jl
+++ b/src/util.jl
@@ -316,6 +316,7 @@ failedat(xs) = (@assert isnull(xs[1]); xs[2])
 struct StrRange
     offset::Int
     length::Int
+    escapecount::Int
 end
 
 function getlineat(str, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,23 +162,13 @@ import TextParse: Quoted, NAToken, Unknown
     @test tryparsenext(Quoted(String, '"', '"'), "\"x\"") |> unwrap == ("x", 4)
     @test tryparsenext(Quoted(String, '"', '"', includequotes=true), "\"x\"") |> unwrap == ("\"x\"", 4)
     str2 =  "\"\"\"\""
-<<<<<<< HEAD
-    @test tryparsenext(Quoted(String, '"', '"'), str2, opts) |> unwrap == ("\"\"", lastindex(str2)+1)
-=======
     @test tryparsenext(Quoted(String), str2, opts) |> unwrap == ("\"", lastindex(str2)+1)
->>>>>>> Progress
     str1 =  "\"x”y\"\"\""
     @test tryparsenext(Quoted(StringToken(String), '"', '"', required=true), "x\"y\"") |> failedat == 1
 
-<<<<<<< HEAD
-    @test tryparsenext(Quoted(String, '"', '"'), str1) |> unwrap == ("x”y\"\"", lastindex(str1)+1)
-    @test tryparsenext(Quoted(StringToken(String), '"', '\\'), "\"x\\\"yz\"") |> unwrap == ("x\\\"yz", 8)
+    @test tryparsenext(Quoted(String, '"', '"'), str1) |> unwrap == ("x”y\"", lastindex(str1)+1)
+    @test tryparsenext(Quoted(StringToken(String), '"', '\\'), "\"x\\\"yz\"") |> unwrap == ("x\"yz", 8)
     @test tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "1") |> unwrap == (1,2)
-=======
-    @test tryparsenext(Quoted(String, escapechar='"'), str1) |> unwrap == ("x”y\"", lastindex(str1)+1)
-    @test tryparsenext(Quoted(StringToken(String), escapechar='\\'), "\"x\\\"yz\"") |> unwrap == ("x\"yz", 8)
-    @test tryparsenext(Quoted(NAToken(fromtype(Int))), "1") |> unwrap == (1,2)
->>>>>>> Progress
 
     t = tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "") |> unwrap
     @test ismissing(t[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,10 +142,10 @@ using WeakRefStrings
 
     opts = LocalOpts(',', false, '"', '\\', false, false)
     str =  "Owner 2 ”Vicepresident\"\""
-    @test tryparsenext(Quoted(String), str, opts) |> unwrap == (str, lastindex(str)+1)
+    @test tryparsenext(Quoted(String, '"', '\\'), str, opts) |> unwrap == (str, lastindex(str)+1)
     str1 =  "\"Owner 2 ”Vicepresident\"\"\""
-    @test tryparsenext(Quoted(String,quotechar='"', escapechar='"'), str1) |> unwrap == ("Owner 2 ”Vicepresident\"", lastindex(str1)+1)
-    @test tryparsenext(Quoted(String), "\"\tx\"") |> unwrap == ("\tx", 5)
+    @test tryparsenext(Quoted(String, '"', '"'), str1) |> unwrap == ("Owner 2 ”Vicepresident\"", lastindex(str1)+1)
+    @test tryparsenext(Quoted(String, '"', '"'), "\"\tx\"") |> unwrap == ("\tx", 5)
     opts = LocalOpts(',', true, '"', '\\', false, false)
     @test tryparsenext(StringToken(String), "x y",1,3, opts) |> unwrap == ("x", 2)
 
@@ -162,7 +162,7 @@ import TextParse: Quoted, NAToken, Unknown
     @test tryparsenext(Quoted(String, '"', '"'), "\"x\"") |> unwrap == ("x", 4)
     @test tryparsenext(Quoted(String, '"', '"', includequotes=true), "\"x\"") |> unwrap == ("\"x\"", 4)
     str2 =  "\"\"\"\""
-    @test tryparsenext(Quoted(String), str2, opts) |> unwrap == ("\"", lastindex(str2)+1)
+    @test tryparsenext(Quoted(String, '"', '"'), str2, opts) |> unwrap == ("\"", lastindex(str2)+1)
     str1 =  "\"x”y\"\"\""
     @test tryparsenext(Quoted(StringToken(String), '"', '"', required=true), "x\"y\"") |> failedat == 1
 
@@ -394,7 +394,7 @@ import TextParse: guesscolparsers
     """
     opts = LocalOpts(',', false, '"', '\\', false, false)
     _, pos = readcolnames(str1, opts, 1, String[])
-    testtill(i, colparsers=[]) = guesscolparsers(str1, String[], opts, pos, i, colparsers)
+    testtill(i, colparsers=[]) = guesscolparsers(str1, String[], opts, pos, i, colparsers, StringArray)
     @test testtill(0) |> first == Any[]
     @test testtill(1) |> first == map(fromtype, [StrRange, Int, Int, Int])
     @test testtill(2) |> first == map(fromtype, [StrRange, Int, Int, Int])
@@ -549,7 +549,7 @@ import TextParse: _csvread
     @test _csvread("") == ((), String[])
 
     @test _csvread("""x""y"", z
-                   a""b"", 1""") == ((["a\"b\""], [1]), ["x\"y\"", "z"])
+                   a""b"", 1""", stringarraytype=Array) == ((["a\"b\""], [1]), ["x\"y\"", "z"])
 end
 
 @testset "skiplines_begin" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,7 +138,7 @@ using WeakRefStrings
 
     opts = LocalOpts(',', false, '"', '"', false, true)
     # test that includequotes option doesn't affect string
-    @test tryparsenext(StringToken(String), "\"\"", opts) |> unwrap == ("\"", 3)
+    @test tryparsenext(StringToken(String), "\"\"", opts) |> unwrap == ("\"\"", 3)
 
     opts = LocalOpts(',', false, '"', '\\', false, false)
     str =  "Owner 2 ”Vicepresident\"\""
@@ -501,9 +501,11 @@ import TextParse: _csvread
     1,2,"x \"\"y\"\""
     """
 
-    res = (([1, 2, 1], [1, 2, 2], String["x", "x", "x \"\"y\"\""]), String["x", "y", "z"])
-    @test _csvread(s, type_detect_rows=1, escapechar='"') == res
-    @test _csvread(s, type_detect_rows=2, escapechar='"') == res
+    res = (([1, 2, 1], [1, 2, 2], String["x", "x", "x \"y\""]), String["x", "y", "z"])
+    @test_broken _csvread(s, type_detect_rows=1, escapechar='"') == res
+    @test_broken _csvread(s, type_detect_rows=2, escapechar='"') == res
+    @test _csvread(s, type_detect_rows=1, escapechar='"', stringarraytype=Array) == res
+    @test _csvread(s, type_detect_rows=2, escapechar='"', stringarraytype=Array) == res
 
     @test csvread(IOBuffer("x\n1")) == (([1],),["x"])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,14 +138,14 @@ using WeakRefStrings
 
     opts = LocalOpts(',', false, '"', '"', false, true)
     # test that includequotes option doesn't affect string
-    @test tryparsenext(StringToken(String), "\"\"", opts) |> unwrap == ("\"\"", 3)
+    @test tryparsenext(StringToken(String), "\"\"", opts) |> unwrap == ("\"", 3)
 
     opts = LocalOpts(',', false, '"', '\\', false, false)
     str =  "Owner 2 ”Vicepresident\"\""
-    @test tryparsenext(Quoted(String, '"', '\\'), str) |> unwrap == (str, lastindex(str)+1)
+    @test tryparsenext(Quoted(String), str, opts) |> unwrap == (str, lastindex(str)+1)
     str1 =  "\"Owner 2 ”Vicepresident\"\"\""
-    @test tryparsenext(Quoted(String,'"', '"'), str1) |> unwrap == (str, lastindex(str1)+1)
-    @test tryparsenext(Quoted(String,'"', '\\'), "\"\tx\"") |> unwrap == ("\tx", 5)
+    @test tryparsenext(Quoted(String,quotechar='"', escapechar='"'), str1) |> unwrap == ("Owner 2 ”Vicepresident\"", lastindex(str1)+1)
+    @test tryparsenext(Quoted(String), "\"\tx\"") |> unwrap == ("\tx", 5)
     opts = LocalOpts(',', true, '"', '\\', false, false)
     @test tryparsenext(StringToken(String), "x y",1,3, opts) |> unwrap == ("x", 2)
 
@@ -162,13 +162,23 @@ import TextParse: Quoted, NAToken, Unknown
     @test tryparsenext(Quoted(String, '"', '"'), "\"x\"") |> unwrap == ("x", 4)
     @test tryparsenext(Quoted(String, '"', '"', includequotes=true), "\"x\"") |> unwrap == ("\"x\"", 4)
     str2 =  "\"\"\"\""
+<<<<<<< HEAD
     @test tryparsenext(Quoted(String, '"', '"'), str2, opts) |> unwrap == ("\"\"", lastindex(str2)+1)
+=======
+    @test tryparsenext(Quoted(String), str2, opts) |> unwrap == ("\"", lastindex(str2)+1)
+>>>>>>> Progress
     str1 =  "\"x”y\"\"\""
     @test tryparsenext(Quoted(StringToken(String), '"', '"', required=true), "x\"y\"") |> failedat == 1
 
+<<<<<<< HEAD
     @test tryparsenext(Quoted(String, '"', '"'), str1) |> unwrap == ("x”y\"\"", lastindex(str1)+1)
     @test tryparsenext(Quoted(StringToken(String), '"', '\\'), "\"x\\\"yz\"") |> unwrap == ("x\\\"yz", 8)
     @test tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "1") |> unwrap == (1,2)
+=======
+    @test tryparsenext(Quoted(String, escapechar='"'), str1) |> unwrap == ("x”y\"", lastindex(str1)+1)
+    @test tryparsenext(Quoted(StringToken(String), escapechar='\\'), "\"x\\\"yz\"") |> unwrap == ("x\"yz", 8)
+    @test tryparsenext(Quoted(NAToken(fromtype(Int))), "1") |> unwrap == (1,2)
+>>>>>>> Progress
 
     t = tryparsenext(Quoted(NAToken(fromtype(Int)), '"', '"'), "") |> unwrap
     @test ismissing(t[1])
@@ -302,12 +312,12 @@ import TextParse: quotedsplit
     @test quotedsplit("\"x\", \"y\"", opts,false, 1, 8) == ["x", "y"]
     @test quotedsplit("\"x\", \"y\"", opts,true, 1, 8) == ["\"x\"", "\"y\""]
     str = """x\nx,"s,", "\\",x" """
-    @test quotedsplit(str, opts, false, 3, length(str)) == ["x", "s,", "\\\",x"]
+    @test quotedsplit(str, opts, false, 3, length(str)) == ["x", "s,", "\",x"]
     @test quotedsplit(",", opts, true, 1, 1) == ["", ""]
     @test quotedsplit(", ", opts, false, 1, 2) == ["", ""]
     str = "1, \"x \"\"y\"\" z\", 1"
     qopts = LocalOpts(',', false,'"', '"', false, false)
-    @test quotedsplit(str, qopts,true, 1, lastindex(str)) == ["1", "\"x \"\"y\"\" z\"", "1"]
+    @test quotedsplit(str, qopts,true, 1, lastindex(str)) == ["1", "\"x \"y\" z\"", "1"]
 end
 
 import TextParse: LocalOpts, readcolnames
@@ -549,7 +559,7 @@ import TextParse: _csvread
     @test _csvread("") == ((), String[])
 
     @test _csvread("""x""y"", z
-                   a""b"", 1""") == ((["a\"\"b\"\""], [1]), ["x\"\"y\"\"", "z"])
+                   a""b"", 1""") == ((["a\"b\""], [1]), ["x\"y\"", "z"])
 end
 
 @testset "skiplines_begin" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -549,7 +549,7 @@ import TextParse: _csvread
     @test _csvread("") == ((), String[])
 
     @test _csvread("""x""y"", z
-                   a""b"", 1""", stringarraytype=Array) == ((["a\"b\""], [1]), ["x\"y\"", "z"])
+                   a""b"", 1""", stringarraytype=Array) == ((["a\"\"b\"\""], [1]), ["x\"\"y\"\"", "z"])
 end
 
 @testset "skiplines_begin" begin


### PR DESCRIPTION
Fixes #85.

@shashi could you take a look whether you are ok with the general strategy here? It is not yet done, but it would be good to get some feedback before I continue with this one here.

I generally have changed how the case of `Vector{String}` is handled: in that case this PR is no longer using `StrRange` at all, but is allocating the `String` in the `tryparsenext` method itself. I didn't see a benefit of going through `StrRange`, and it cuts down on the places that need to handle the escaping stuff.

This does *not yet* work with `StringArray`. I'm not sure I'll have the time to implement this for `StringArray` as well, in particular given that I'm not using it at all. Maybe someone from the JuliaDB team could sort out that part? Or, alternatively, but clearly not ideal, we could also for now just fix the bug for the `Vector{String}` case and then later try to fix it for `StringArray` as well.

Oh, and it would be great if you could carefully look over my changes to the tests. I think they now reflect a world in which escape char is handled properly, but it would be good to have that double checked :)