### PR TITLE
Fix a bug on julia 1.2

### DIFF
--- a/src/VectorBackedStrings.jl
+++ b/src/VectorBackedStrings.jl
@@ -35,10 +35,10 @@ Base.@propagate_inbounds function Base.iterate(s::VectorBackedUTF8String, i::Int
     b = codeunit(s, i)
     u = UInt32(b) << 24
     Base.between(b, 0x80, 0xf7) || return reinterpret(Char, u), i+1
-    return Base.next_continued(s, i, u)
+    return our_next_continued(s, i, u)
 end
 
-function Base.next_continued(s::VectorBackedUTF8String, i::Int, u::UInt32)
+function our_next_continued(s::VectorBackedUTF8String, i::Int, u::UInt32)
     u < 0xc0000000 && (i += 1; @goto ret)
     n = ncodeunits(s)
     # first continuation byte


### PR DESCRIPTION
`next_continued` is being renamed in julia 1.2. Simplest solution is to just ignore the base function here and define our own own.