### PR TITLE
Fix bug in min_with_max_digits

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -93,7 +93,7 @@ end
 end
 
 Base.@pure maxdigits(::Type{T}) where {T} = ndigits(typemax(T))
-Base.@pure min_with_max_digits(::Type{T}) where {T} = convert(T, 10^(ndigits(typemax(T))-1))
+Base.@pure min_with_max_digits(::Type{T}) where {T} = convert(T, T(10)^(maxdigits(T)-1))
 
 @inline function tryparsenext_base10(T, str,i,len)
     i0 = i
@@ -108,7 +108,7 @@ Base.@pure min_with_max_digits(::Type{T}) where {T} = convert(T, 10^(ndigits(typ
         y2 === nothing && return R(convert(T, 0)), i
         r = y2[1]; i = y2[2]
     end
-   
+
     digits = 1
     ten = T(10)
     while true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,7 +111,12 @@ end
     @test tryparsenext(fromtype(Int64), "9223372036854775807", 1, 19) |> unwrap == (9223372036854775807, 20)
     @test tryparsenext(fromtype(Int64), "9223372036854775808", 1, 19) |> failedat == 1
     @test tryparsenext(fromtype(Int64), "19223372036854775808", 1, 20) |> failedat == 1
-
+    @test tryparsenext(fromtype(UInt64), "18446744073709551615", 1, 20) |> unwrap == (0xffffffffffffffff, 21)
+    @test tryparsenext(fromtype(UInt64), "18446744073709551616", 1, 20) |> failedat == 1
+    @test tryparsenext(fromtype(Int128), "170141183460469231731687303715884105727", 1, 39) |> unwrap == (170141183460469231731687303715884105727, 40)
+    @test tryparsenext(fromtype(Int128), "170141183460469231731687303715884105728", 1, 39) |> failedat == 1
+    @test tryparsenext(fromtype(UInt128), "340282366920938463463374607431768211455", 1, 39) |> unwrap == (0xffffffffffffffffffffffffffffffff, 40)
+    @test tryparsenext(fromtype(UInt128), "340282366920938463463374607431768211456", 1, 39) |> failedat == 1
 end
 
 import TextParse: StringToken


### PR DESCRIPTION
I also added tests for `typemax(T)` and `typemax(T) + 1` for `T = [UInt64, Int128, UInt128]`.

Fixes #119 
