### PR TITLE
Always quote string

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -419,7 +419,7 @@ function _csvread_internal(str::AbstractString, delim=',';
 end
 
 function promote_field(failed_str, field, col, err, nastrings, stringtype, stringarraytype, opts)
-    newtoken = guesstoken(failed_str, opts, field.inner, nastrings, stringarraytype)
+    newtoken = guesstoken(failed_str, opts, false, field.inner, nastrings, stringarraytype)
     if newtoken == field.inner
         # no need to change
         return field, col
@@ -518,7 +518,7 @@ function guesscolparsers(str::AbstractString, header, opts::LocalOpts, pos::Int,
                 error("previous rows had $(length(guess)) fields but row $i2 has $(length(fields))")
             end
             try
-                guess[j] = guesstoken(fields[j], opts, guess[j], nastrings, stringarraytype)
+                guess[j] = guesstoken(fields[j], opts, false, guess[j], nastrings, stringarraytype)
             catch err
                 println(stderr, "Error while guessing a common type for column $j")
                 println(stderr, "new value: $(fields[j]), prev guess was: $(guess[j])")

--- a/src/field.jl
+++ b/src/field.jl
@@ -449,7 +449,7 @@ end
 - `escapechar`: character that escapes the quote char (default set by `LocalOpts`)
 """
 function Quoted(inner::S,
-    quotechar::T_QUOTECHAR, escapechar::T_ESCAPECHAR;
+    quotechar::T_QUOTECHAR=UInt8('"'), escapechar::T_ESCAPECHAR=UInt8('"');
     required=false,
     stripwhitespaces=fieldtype(S)<:Number,
     includequotes=false,
@@ -460,7 +460,7 @@ function Quoted(inner::S,
                 includenewlines, quotechar, escapechar)
 end
 
-Quoted(t::Type, quotechar, escapechar; kwargs...) = Quoted(fromtype(t), quotechar, escapechar; kwargs...)
+Quoted(t::Type, quotechar=UInt8('"'), escapechar=UInt8('"'); kwargs...) = Quoted(fromtype(t), quotechar, escapechar; kwargs...)
 
 function tryparsenext(q::Quoted{T,S,T_QUOTECHAR,T_ESCAPECHAR}, str, i, len, opts) where {T,S,T_QUOTECHAR,T_ESCAPECHAR}
     y1 = iterate(str, i)

--- a/src/field.jl
+++ b/src/field.jl
@@ -449,7 +449,7 @@ end
 - `escapechar`: character that escapes the quote char (default set by `LocalOpts`)
 """
 function Quoted(inner::S,
-    quotechar::T_QUOTECHAR=UInt8('"'), escapechar::T_ESCAPECHAR=UInt8('"');
+    quotechar::T_QUOTECHAR, escapechar::T_ESCAPECHAR;
     required=false,
     stripwhitespaces=fieldtype(S)<:Number,
     includequotes=false,
@@ -460,7 +460,7 @@ function Quoted(inner::S,
                 includenewlines, quotechar, escapechar)
 end
 
-Quoted(t::Type, quotechar=UInt8('"'), escapechar=UInt8('"'); kwargs...) = Quoted(fromtype(t), quotechar, escapechar; kwargs...)
+Quoted(t::Type, quotechar, escapechar; kwargs...) = Quoted(fromtype(t), quotechar, escapechar; kwargs...)
 
 function tryparsenext(q::Quoted{T,S,T_QUOTECHAR,T_ESCAPECHAR}, str, i, len, opts) where {T,S,T_QUOTECHAR,T_ESCAPECHAR}
     y1 = iterate(str, i)

--- a/src/guesstype.jl
+++ b/src/guesstype.jl
@@ -52,7 +52,7 @@ function getquotechar(x)
     return '\0'
 end
 
-function guesstoken(x, opts, @nospecialize(prev_guess)=Unknown(), nastrings=NA_STRINGS, stringarraytype=StringArray)
+function guesstoken(x, opts, prevent_quote_wrap, @nospecialize(prev_guess)=Unknown(), nastrings=NA_STRINGS, stringarraytype=StringArray)
     q = getquotechar(x)
 
     if isa(prev_guess, StringToken)
@@ -65,19 +65,19 @@ function guesstoken(x, opts, @nospecialize(prev_guess)=Unknown(), nastrings=NA_S
         else
             prev_inner = prev_guess
         end
-        inner_token = guesstoken(strip(strip(x, q)), opts, prev_inner, nastrings, stringarraytype)
+        inner_token = guesstoken(strip(strip(x, q)), opts, true, prev_inner, nastrings, stringarraytype)
         return Quoted(inner_token, opts.quotechar, opts.escapechar)
     elseif isa(prev_guess, Quoted)
         # but this token is not quoted
-        return Quoted(guesstoken(x, opts, prev_guess.inner, nastrings, stringarraytype), opts.quotechar, opts.escapechar)
+        return Quoted(guesstoken(x, opts, true, prev_guess.inner, nastrings, stringarraytype), opts.quotechar, opts.escapechar)
     elseif isa(prev_guess, NAToken)
         # This column is nullable
         if isna(x, nastrings)
             # x is null too, return previous guess
             return prev_guess
         else
-            tok = guesstoken(x, opts, prev_guess.inner, nastrings, stringarraytype)
-            if isa(tok, StringToken)
+            tok = guesstoken(x, opts, false, prev_guess.inner, nastrings, stringarraytype)
+            if isa(tok, Quoted) && isa(tok.inner, StringToken)
                 return tok # never wrap a string in NAToken
             elseif isa(tok, Quoted)
                 # Always put the quoted wrapper on top
@@ -108,17 +108,20 @@ function guesstoken(x, opts, @nospecialize(prev_guess)=Unknown(), nastrings=NA_S
                 return Numeric(promote_type(T, fieldtype(prev_guess)))
             else
                 # something like a date turned into a single number?
-                return StringToken(stringarraytype<:StringArray ? StrRange : String)
+                y1 = StringToken(stringarraytype<:StringArray ? StrRange : String)
+                return prevent_quote_wrap ? y1 : Quoted(y1, opts.quotechar, opts.escapechar)
             end
         else
             # fast-path
             if length(filter(isnumeric, x)) < 4
-                return StringToken(stringarraytype<:StringArray ? StrRange : String)
+                y2 = StringToken(stringarraytype<:StringArray ? StrRange : String)
+                return prevent_quote_wrap ? y2 : Quoted(y2, opts.quotechar, opts.escapechar)
             end
 
             maybedate = guessdateformat(x)
             if maybedate === nothing
-                return StringToken(stringarraytype<:StringArray ? StrRange : String)
+                y3 = StringToken(stringarraytype<:StringArray ? StrRange : String)
+                return prevent_quote_wrap ? y3 : Quoted(y3, opts.quotechar, opts.escapechar)
             else
                 return maybedate
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,11 +401,11 @@ import TextParse: guesscolparsers
     _, pos = readcolnames(str1, opts, 1, String[])
     testtill(i, colparsers=[]) = guesscolparsers(str1, String[], opts, pos, i, colparsers, StringArray)
     @test testtill(0) |> first == Any[]
-    @test testtill(1) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Int), fromtype(Int), fromtype(Int)]
-    @test testtill(2) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Int), fromtype(Int), fromtype(Int)]
-    @test testtill(3) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Int), fromtype(Float64), fromtype(Int)]
-    @test testtill(4) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Float64), fromtype(Float64), NAToken(fromtype(Int))]
-    @test testtill(5) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Float64), NAToken(fromtype(fromtype(Float64))), NAToken(fromtype(Int))]
+    @test testtill(1) |> first == Any[Quoted(StringToken(StrRange), '"', '"'), fromtype(Int), fromtype(Int), fromtype(Int)]
+    @test testtill(2) |> first == Any[Quoted(StringToken(StrRange), '"', '"'), fromtype(Int), fromtype(Int), fromtype(Int)]
+    @test testtill(3) |> first == Any[Quoted(StringToken(StrRange), '"', '"'), fromtype(Int), fromtype(Float64), fromtype(Int)]
+    @test testtill(4) |> first == Any[Quoted(StringToken(StrRange), '"', '"'), fromtype(Float64), fromtype(Float64), NAToken(fromtype(Int))]
+    @test testtill(5) |> first == Any[Quoted(StringToken(StrRange), '"', '"'), fromtype(Float64), NAToken(fromtype(Float64)), NAToken(fromtype(Int))]
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,14 +401,11 @@ import TextParse: guesscolparsers
     _, pos = readcolnames(str1, opts, 1, String[])
     testtill(i, colparsers=[]) = guesscolparsers(str1, String[], opts, pos, i, colparsers, StringArray)
     @test testtill(0) |> first == Any[]
-    @test testtill(1) |> first == map(fromtype, [StrRange, Int, Int, Int])
-    @test testtill(2) |> first == map(fromtype, [StrRange, Int, Int, Int])
-    @test testtill(3) |> first == map(fromtype, [StrRange, Int, Float64, Int])
-    @test testtill(4) |> first == vcat(map(fromtype, [StrRange, Float64, Float64]),
-                                       NAToken(fromtype(Int)))
-    @test testtill(5) |> first == vcat(map(fromtype, [StrRange, Float64]),
-                                       NAToken(fromtype(Float64)),
-                                       NAToken(fromtype(Int)))
+    @test testtill(1) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Int), fromtype(Int), fromtype(Int)]
+    @test testtill(2) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Int), fromtype(Int), fromtype(Int)]
+    @test testtill(3) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Int), fromtype(Float64), fromtype(Int)]
+    @test testtill(4) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Float64), fromtype(Float64), NAToken(fromtype(Int))]
+    @test testtill(5) |> first == Any[Quoted(StringToken(StrRange)), fromtype(Float64), NAToken(fromtype(fromtype(Float64))), NAToken(fromtype(Int))]
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,52 +339,52 @@ import TextParse: guesstoken, Unknown, Numeric, DateTimeToken, StrRange
 @testset "guesstoken" begin
     opts = LocalOpts(UInt8(','), false, UInt8('"'), UInt8('"'), false, false)
     # Test null values
-    @test guesstoken("", opts, Unknown()) == NAToken(Unknown())
-    @test guesstoken("null", opts, Unknown()) == NAToken(Unknown())
-    @test guesstoken("", opts, NAToken(Unknown())) == NAToken(Unknown())
-    @test guesstoken("null", opts, NAToken(Unknown())) == NAToken(Unknown())
+    @test guesstoken("", opts, false, Unknown()) == NAToken(Unknown())
+    @test guesstoken("null", opts, false, Unknown()) == NAToken(Unknown())
+    @test guesstoken("", opts, false, NAToken(Unknown())) == NAToken(Unknown())
+    @test guesstoken("null", opts, false, NAToken(Unknown())) == NAToken(Unknown())
 
     # Test NA
-    @test guesstoken("1", opts, NAToken(Unknown())) == NAToken(Numeric(Int))
-    @test guesstoken("1", opts, NAToken(Numeric(Int))) == NAToken(Numeric(Int))
-    @test guesstoken("", opts, NAToken(Numeric(Int))) == NAToken(Numeric(Int))
-    @test guesstoken("1%", opts, NAToken(Unknown())) == NAToken(Percentage())
+    @test guesstoken("1", opts, false, NAToken(Unknown())) == NAToken(Numeric(Int))
+    @test guesstoken("1", opts, false, NAToken(Numeric(Int))) == NAToken(Numeric(Int))
+    @test guesstoken("", opts, false, NAToken(Numeric(Int))) == NAToken(Numeric(Int))
+    @test guesstoken("1%", opts, false, NAToken(Unknown())) == NAToken(Percentage())
 
     # Test non-null numeric
-    @test guesstoken("1", opts, Unknown()) == Numeric(Int)
-    @test guesstoken("1", opts, Numeric(Int)) == Numeric(Int)
-    @test guesstoken("", opts, Numeric(Int)) == NAToken(Numeric(Int))
-    @test guesstoken("1.0", opts, Numeric(Int)) == Numeric(Float64)
+    @test guesstoken("1", opts, false, Unknown()) == Numeric(Int)
+    @test guesstoken("1", opts, false, Numeric(Int)) == Numeric(Int)
+    @test guesstoken("", opts, false, Numeric(Int)) == NAToken(Numeric(Int))
+    @test guesstoken("1.0", opts, false, Numeric(Int)) == Numeric(Float64)
 
     # Test strings
-    @test guesstoken("x", opts, Unknown()) == StringToken(StrRange)
+    @test guesstoken("x", opts, false, Unknown()) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
 
     # Test nullable to string
-    @test guesstoken("x", opts, NAToken(Unknown())) == StringToken(StrRange)
+    @test guesstoken("x", opts, false, NAToken(Unknown())) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
 
     # Test string to non-null (short circuit)
-    @test guesstoken("1", opts, StringToken(StrRange)) == StringToken(StrRange)
+    @test guesstoken("1", opts, false, StringToken(StrRange)) == StringToken(StrRange)
 
     # Test quoting
-    @test guesstoken("\"1\"", opts, Unknown()) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"1\"", opts, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"1\"", opts, false, Unknown()) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"1\"", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
 
     # Test quoting with Nullable tokens
-    @test guesstoken("\"\"", opts, Quoted(Unknown(), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, Unknown()) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, Numeric(Int)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
-    @test guesstoken("", opts, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
-    @test guesstoken("", opts, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
-    @test guesstoken("1", opts, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"1\"", opts, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Quoted(Unknown(), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Unknown()) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Numeric(Int)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("", opts, false, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("1", opts, false, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"1\"", opts, false, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
 
     # Test DateTime detection:
-    tok = guesstoken("2016-01-01 10:10:10.10", opts, Unknown())
+    tok = guesstoken("2016-01-01 10:10:10.10", opts, false, Unknown())
     @test tok == DateTimeToken(DateTime, dateformat"yyyy-mm-dd HH:MM:SS.s")
-    @test guesstoken("2016-01-01 10:10:10.10", opts, tok) == tok
-    @test guesstoken("2016-01-01 10:10:10.10", opts, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(tok), opts.quotechar, opts.escapechar)
+    @test guesstoken("2016-01-01 10:10:10.10", opts, false, tok) == tok
+    @test guesstoken("2016-01-01 10:10:10.10", opts, false, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(tok), opts.quotechar, opts.escapechar)
 end
 
 import TextParse: guesscolparsers


### PR DESCRIPTION
Fixes #125.

This changes the guess logic so that string columns always end up as a quoted string. That is the goal, I'm not a 100% sure I made all the necessary changes for that.

I think we should always parse string columns as quoted. The reason is Excel: in a string column, it will only use quotes in rows where they are needed. So if there is a string column and in a row way down there is a `,` in the string, then Excel will _not_ use quotes up until that row, and then use quotes just for that one cell. Our current logic will detect such a column as string (without quote), and then cannot recover from the row later that does use quotes: it will come across a line like this `", bar"`, and now it will read the content of the first column as just `"`, which is incorrect.

Long story short, I think there are lots of CSV files out there that have string columns where some rows use quotes and others don't, and the only way to read those properly seems to just always treat string columns as potentially having quotes.

I still need to fix tests, but wanted to get @shashi's general reaction first before I put more time into this.