### PR TITLE
Escape a string

### DIFF
--- a/src/guesstype.jl
+++ b/src/guesstype.jl
@@ -17,7 +17,7 @@ const common_datetime_formats = Any[
     dateformat"yyyymmdd HH:MM:SS.s"
 ]
 
-const DEFAULT_QUOTES = ('"', ''')
+const DEFAULT_QUOTES = ('"', '\'')
 
 function guessdateformat(str)
 


### PR DESCRIPTION
the old way worked as well, but threw of the syntax highlighting in editors.