### PR TITLE
Detect "" always as quoted string column

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -370,11 +370,11 @@ import TextParse: guesstoken, Unknown, Numeric, DateTimeToken, StrRange
     @test guesstoken("\"1\"", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(Numeric(Int), opts.quotechar, opts.escapechar)
 
     # Test quoting with Nullable tokens
-    @test guesstoken("\"\"", opts, false, Quoted(Unknown(), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, false, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, false, Unknown()) == Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)
-    @test guesstoken("\"\"", opts, false, Numeric(Int)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Quoted(Unknown(), opts.quotechar, opts.escapechar)) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Quoted(NAToken(Unknown()), opts.quotechar, opts.escapechar)) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Unknown()) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
+    @test guesstoken("\"\"", opts, false, Numeric(Int)) == Quoted(StringToken(StrRange), opts.quotechar, opts.escapechar)
     @test guesstoken("", opts, false, Quoted(Numeric(Int), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
     @test guesstoken("", opts, false, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)
     @test guesstoken("1", opts, false, Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)) == Quoted(NAToken(Numeric(Int)), opts.quotechar, opts.escapechar)


### PR DESCRIPTION
Fixes https://github.com/JuliaComputing/JuliaDB.jl/issues/267.

This changes the column type detection logic for empty quoted strings. With this change, any `""` is now _always_ detected as a quoted string, end of story. Right now I think that makes the most sense, but I'm not super sure?

It seems generally weird to detect `""` as a missing value, in general. I think it makes sense to detected say `,,` as missing (i.e. the column between the two commas), but I think as soon as there are quotes there, we should interpret it as "there is a value, namely an empty string".

@shashi and @joshday can you think about this as well a bit? I feel this is the kind of change where it helps to poll a bunch of folks to make sure I don't overlooked some important corner case :)

There is probably another fix for the that is linked above, but this seemed the most straightforward one to me...