### PR TITLE
Reparse

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -329,6 +329,9 @@ function _csvread_internal(str::AbstractString, delim=',';
         resizecols(colspool, nrows)
     end
 
+    lineno_start_of_data = lineno
+    pos_start_of_data = pos
+
     finalrows = rowno
     @label retry
     try
@@ -382,7 +385,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                 lineno = err.lineno+1
                 @goto retry
             end
-            @info failed_strs
+
             reparse_needed = fill(false, length(cols))
             promoted = map(failed_strs, err.colno:length(cols)) do s, colidx
                 col = cols[colidx]
@@ -391,13 +394,33 @@ function _csvread_internal(str::AbstractString, delim=',';
                 c = promote_field(s, f, col, err, nastrings, stringtype, stringarraytype, opts)
                 if c[2]==:reparserequired
                     reparse_needed[colidx] = true
-                else
-                    colspool[name] = c[2]
+                    c = c[1], stringarraytype{stringtype,1}(undef, nrows)
                 end
+                colspool[name] = c[2]
                 c
             end
 
-            @info reparse_needed
+            if any(reparse_needed)
+                new_fields = [reparse_needed[i] ? tofield(String, opts, stringarraytype) : tofield(nothing, opts, stringarraytype) for i in 1:length(reparse_needed)]
+                new_fields[end] = swapinner(new_fields[end], new_fields[end], eoldelim=true)
+                rec2 = Record((new_fields...,))
+
+                cols2 = makeoutputvecs(rec2, nrows, stringtype, stringarraytype)
+                for (iii, val) in enumerate(cols2)
+                    if val!==nothing
+                        colspool[iii] = val
+                    end
+                end
+
+                finalrows2 = parsefill!(str, opts, rec2, nrows, cols2, colspool,
+                    pos_start_of_data, lineno_start_of_data, 1, l, commentchar)
+
+                for iii=err.colno:length(cols)
+                    if reparse_needed[iii]
+                        promoted[iii] = (promoted[iii][1], cols2[iii])
+                    end
+                end
+            end
 
             newfields = map(first, promoted)
             newcols = map(last, promoted)
@@ -443,8 +466,6 @@ function promote_field(failed_str, field, col, err, nastrings, stringtype, strin
         # no need to change
         return field, col
     end
-    @info newtoken
-    @info typeof(newtoken)
     if newtoken isa StringToken || (newtoken isa Quoted && newtoken.inner isa StringToken)
         return swapinner(field, newtoken), :reparserequired
     end

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -417,7 +417,7 @@ function _csvread_internal(str::AbstractString, delim=',';
 
                 for iii=err.colno:length(cols)
                     if reparse_needed[iii]
-                        promoted[iii] = (promoted[iii][1], cols2[iii])
+                        promoted[iii-err.colno+1] = (promoted[iii-err.colno+1][1], cols2[iii])
                     end
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -493,13 +493,33 @@ import TextParse: _csvread
     @test isequal(data, _csvread(str1, type_detect_rows=2))
     @test isequal(data, _csvread(str1, type_detect_rows=3))
     @test isequal(data, _csvread(str1, type_detect_rows=4))
-    # But we can't go from a non-string column to a string column
+
+    # Test reparsing as a string column
     str3 = """
      a, b,c d, e
     1,1,1,1
     x,1,1,1
     """
-    @test_throws TextParse.CSVParseError _csvread(str3, type_detect_rows=1)
+    coltype_test4 = _csvread(str3, type_detect_rows=1)
+    @test isequal(((["1","x"], [1,1], [1,1], [1,1]),["a","b","c d","e"]), coltype_test4)
+
+    str4 = """
+     a, b,c d, e
+    1,1,01,1
+    2,1,x,1
+    y,2,3,8
+    """
+    coltype_test4 = _csvread(str4, type_detect_rows=1)
+    @test isequal(((["1","2", "y"], [1,1,2], ["01","x", "3"], [1,1,8]),["a","b","c d","e"]), coltype_test4)
+
+    str5 = """
+     a, b,c d, e
+    1,1,4,01.1
+    02,1,3,x
+    y,2,3,8
+    """
+    coltype_test4 = _csvread(str5, type_detect_rows=1)
+    @test isequal(((["1","02", "y"], [1,1,2], [4,3,3], ["01.1","x","8"]),["a","b","c d","e"]), coltype_test4)
 
     # test growing of columns if prediction is too low
     @test _csvread("x,y\nabcd, defg\n,\n,\n", type_detect_rows=1) ==
@@ -638,7 +658,7 @@ import TextParse: _csvread
     #2,2,2
     """
 
-    # Since we are not skipping commented lines the '#' character is considered 
+    # Since we are not skipping commented lines the '#' character is considered
     # data. This will force parsing to treat columns with '#'s as String columns.
     # Here, we verify this behavior.
     result = _csvread(str7)


### PR DESCRIPTION
If there is a parsing error that requires a column to be promoted from a non string type to a string type, then this PR will reparse that specific column as a string column and things should just work. I believe this should fix any remaining inability to parse valid CSV files. The strategy here is the same that R's fread from data.table uses.

Still needs
- [x] tests

Fixes #64.